### PR TITLE
[Feat] [BE] 모임 CRUD 및 참가 신청/관리 기능 구현 (#30,#33)

### DIFF
--- a/backend/src/main/java/com/nathing/banthing/config/SchedulingConfig.java
+++ b/backend/src/main/java/com/nathing/banthing/config/SchedulingConfig.java
@@ -1,0 +1,26 @@
+package com.nathing.banthing.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+/**
+ * 스케줄링 기능을 활성화시키기 위한 Spring 설정 클래스입니다.
+ *
+ * 이 클래스는 애플리케이션에서 스케줄링 작업을 수행할 수 있도록 설정을 활성화합니다.
+ * 또한, @EnableScheduling 어노테이션을 사용하여 Spring의 스케줄링 메커니즘을 설정합니다.
+ *
+ * 주요 역할:
+ * - 일정 작업(task)을 정의하고 주기적으로 실행할 수 있는 환경을 설정합니다.
+ * - 스프링 애플리케이션에서 @Scheduled 어노테이션을 사용하여 실행 가능한 메서드를 작성할 수 있습니다.
+ *
+ * 사용된 어노테이션:
+ * - @Configuration: Spring의 설정 파일임을 나타내며, Bean을 정의하거나 설정을 담당하는 클래스임을 표시합니다.
+ * - @EnableScheduling: 애플리케이션에서 스케줄링 기능을 활성화합니다.
+ *
+ * @author 고동현
+ * @since 2025-09-15
+ */
+@Configuration
+@EnableScheduling
+public class SchedulingConfig {
+}

--- a/backend/src/main/java/com/nathing/banthing/config/SecurityConfig.java
+++ b/backend/src/main/java/com/nathing/banthing/config/SecurityConfig.java
@@ -33,8 +33,10 @@ public class SecurityConfig {
             "/api/auth/**",
             "/oauth2/**",
             "/login/oauth2/**",
-            "/api/some-public-data"
+            "/api/some-public-data",
+            "/api/meetings/search", // 전체 조회만 허용
             // 앞으로 추가될 퍼블릭 엔드포인트를 여기에 나열합니다.
+
     };
 
     // 시큐리티 필터체인 빈을 등록

--- a/backend/src/main/java/com/nathing/banthing/controller/MeetingController.java
+++ b/backend/src/main/java/com/nathing/banthing/controller/MeetingController.java
@@ -3,35 +3,56 @@ package com.nathing.banthing.controller;
 import com.nathing.banthing.dto.common.ApiResponse;
 import com.nathing.banthing.dto.request.MeetingCreateRequest;
 import com.nathing.banthing.dto.request.MeetingUpdateRequest;
-import com.nathing.banthing.dto.response.MeetingCreateResponse;
-import com.nathing.banthing.dto.response.MeetingDetailResponse;
-import com.nathing.banthing.dto.response.MeetingSimpleResponse;
-import com.nathing.banthing.dto.response.MeetingUpdateResponse;
+import com.nathing.banthing.dto.response.*;
 import com.nathing.banthing.entity.Meeting;
-import com.nathing.banthing.exception.BusinessException;
-import com.nathing.banthing.exception.ErrorCode;
 import com.nathing.banthing.repository.MeetingsRepository;
-import com.nathing.banthing.service.CreateMeetingService;
-import com.nathing.banthing.service.DeleteMeetingService;
-import com.nathing.banthing.service.FindMeetingService;
-import com.nathing.banthing.service.UpdateMeetingService;
+import com.nathing.banthing.service.*;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
 /**
- * 모임 관리와 관련된 REST API를 제공하는 컨트롤러 클래스.
- * API 엔드포인트를 통해 모임 생성, 조회, 수정, 삭제 작업을 수행.
+ * MeetingController는 모임과 관련된 다양한 기능을 제공하는 REST API 컨트롤러 클래스입니다.
+ *
+ * 이 컨트롤러는 모임의 생성, 조회, 수정, 삭제, 참가 신청, 모집 마감 등
+ * 모임 관리와 관련된 모든 주요 작업에 대해 HTTP 요청을 처리합니다.
+ * 각 메서드는 특정 작업을 수행하며, 요청 경로, HTTP 메서드, 요청 데이터 및
+ * 응답 데이터를 명확히 정의합니다.
+ *
+ * 주요 기능:
+ * - 모임 생성
+ * - 전체 모임 목록 조회
+ * - 특정 모임 상세 조회
+ * - 모임 수정
+ * - 모임 삭제
+ * - 참가 신청 및 신청 목록 조회
+ * - 참가 신청 승인
+ * - 모집 마감 기능
+ *
+ * 각 메서드는 클라이언트가 API 호출을 통해 모임 데이터를 관리할 수 있도록 하며,
+ * 데이터의 유효성 검증 및 인증, 권한 체크 등의 작업을 포함합니다.
+ *
+ * 의존 서비스:
+ * - CreateMeetingService: 모임 생성 관련 로직 처리
+ * - FindMeetingService: 모임 조회 관련 로직 처리
+ * - UpdateMeetingService: 모임 수정 관련 로직 처리
+ * - DeleteMeetingService: 모임 삭제 관련 로직 처리
+ * - JoinMeetingService: 모임 참가 신청 및 승인 관련 로직 처리
+ * - ManageMeetingService: 모임 관리(참가 신청 승인, 모집 마감 등) 관련 로직 처리
+ *
+ * 유효성 검사와 인증:
+ * - `@Valid` 어노테이션을 활용하여 요청 데이터의 유효성을 검사합니다.
+ * - `@AuthenticationPrincipal` 어노테이션으로 현재 사용자의 인증 정보를 자동 주입합니다.
+ *
  * @author 고동현
  * @since - 2025-09-15
  */
+
 @RestController
 @RequestMapping("/api/meetings")
 @RequiredArgsConstructor
@@ -42,6 +63,9 @@ public class MeetingController {
     private final MeetingsRepository meetingsRepository;
     private final UpdateMeetingService updateMeetingService;
     private final DeleteMeetingService deleteMeetingService;
+    private final JoinMeetingService joinMeetingService;
+    private final ManageMeetingService manageMeetingService;
+
 
     /**
      * 모임 생성 API
@@ -137,4 +161,118 @@ public class MeetingController {
 
         return ResponseEntity.ok(apiResponse);
     }
+
+    /**
+     * 모임 참가 신청 API
+     *
+     * @param meetingId 참가 신청할 모임의 ID
+     * @param currentUserId 현재 로그인한 사용자의 ID (자동 주입)
+     * @return 성공 응답
+     */
+    @PostMapping("/{meetingId}/join")
+    public ResponseEntity<ApiResponse<Void>> joinMeeting(
+            @PathVariable Long meetingId,
+            @AuthenticationPrincipal Long currentUserId) {
+
+        joinMeetingService.joinMeeting(meetingId, currentUserId);
+
+        ApiResponse<Void> apiResponse = ApiResponse.success("모임 참가 신청이 완료되었습니다.", null);
+
+        return ResponseEntity.ok(apiResponse);
+    }
+
+    /**
+     * 모임 참가 신청 목록 조회 API (호스트 전용)
+     *
+     * @param meetingId 신청 목록을 조회할 모임의 ID
+     * @param currentUserId 현재 로그인한 사용자의 ID (자동 주입)
+     * @return 참가 신청 목록
+     */
+    @GetMapping("/{meetingId}/participants")
+    public ResponseEntity<ApiResponse<List<MeetingParticipantResponse>>> getParticipants(
+            @PathVariable Long meetingId,
+            @AuthenticationPrincipal Long currentUserId) {
+
+        List<MeetingParticipantResponse> participants = joinMeetingService.getPendingParticipants(meetingId, currentUserId);
+
+        ApiResponse<List<MeetingParticipantResponse>> apiResponse = ApiResponse.success("참가 신청 목록이 성공적으로 조회되었습니다.", participants);
+
+        return ResponseEntity.ok(apiResponse);
+    }
+
+    /**
+     * 참가자의 모임 참가 신청을 승인하는 메서드입니다.
+     *
+     * 이 API는 주최자(호스트)가 특정 모임(meetingId)에 대해 특정 참가자(participantId)의
+     * 참가 신청을 승인할 때 호출됩니다. 성공적으로 승인되었을 경우,
+     * 응답으로 성공 메시지와 상태 코드 200을 반환합니다.
+     *
+     * @param meetingId 모임의 고유 식별자(ID)입니다.
+     * @param participantId 승인할 참가자의 고유 식별자(ID)입니다.
+     * @param hostId 현재 인증된 사용자의 고유 식별자(ID)로서, 주최자(호스트)를 나타냅니다.
+     * @return 참가 신청 승인 작업이 성공적으로 완료되었음을 나타내는 응답 객체입니다.
+     */
+    @PostMapping("/{meetingId}/participants/{participantId}/approve")
+    public ResponseEntity<ApiResponse<Void>> approveParticipant(
+            @PathVariable Long meetingId,
+            @PathVariable Long participantId,
+            @AuthenticationPrincipal Long hostId) {
+        manageMeetingService.approveParticipant(meetingId, participantId, hostId);
+        return ResponseEntity.ok(ApiResponse.success("참가 신청이 승인되었습니다.", null));
+    }
+
+    /**
+     * 모집을 마감하는 API 핸들러 메서드입니다.
+     *
+     * 이 메서드는 주어진 모임 ID와 호스트 ID를 사용하여 모집 마감 로직을 수행합니다.
+     * 성공적으로 실행된 경우, 모집이 마감되었다는 메시지를 포함한 응답을 반환합니다.
+     *
+     * @param meetingId 모집을 마감할 모임의 고유 식별자 (PathVariable로 전달됨)
+     * @param hostId 현재 요청을 보낸 사용자의 ID로, 인증 정보에서 추출됨 (AuthenticationPrincipal로 전달됨)
+     * @return 모집 마감 성공 메시지가 포함된 응답
+     */
+    @PostMapping("/{meetingId}/close-recruitment")
+    public ResponseEntity<ApiResponse<Void>> closeRecruitment(
+            @PathVariable Long meetingId,
+            @AuthenticationPrincipal Long hostId) {
+        manageMeetingService.closeRecruitment(meetingId, hostId);
+        return ResponseEntity.ok(ApiResponse.success("모집이 마감되었습니다.", null));
+    }
+
+    /**
+     * 사용자가 특정 모임에서 탈퇴하는 기능을 처리하는 메서드입니다.
+     *
+     * 요청 경로의 모임 ID와 인증된 사용자 ID를 이용하여 사용자가 해당 모임에서 탈퇴하도록 처리합니다.
+     * 성공적으로 처리된 경우, 성공 메시지와 함께 응답이 반환됩니다.
+     *
+     * @param meetingId 탈퇴하려는 모임의 고유 식별자 (path variable)
+     * @param userId 인증된 사용자의 고유 식별자 (authentication principal)
+     * @return ApiResponse 객체를 감싼 ResponseEntity로 처리 결과를 반환합니다. 성공적으로 처리된 경우 "모임에서 탈퇴하였습니다." 메시지가 포함됩니다.
+     */
+    @PostMapping("/{meetingId}/leave")
+    public ResponseEntity<ApiResponse<Void>> leaveMeeting(
+            @PathVariable Long meetingId,
+            @AuthenticationPrincipal Long userId) {
+        manageMeetingService.leaveMeeting(meetingId, userId);
+        return ResponseEntity.ok(ApiResponse.success("모임에서 탈퇴하였습니다.", null));
+    }
+
+    /**
+     * 주어진 모임 ID와 호스트 ID를 기반으로 모임을 완료 상태로 변경하는 메서드입니다.
+     * 모임 완료 처리가 성공적으로 이루어진 경우, 적절한 API 응답 메시지를 반환합니다.
+     *
+     * @param meetingId 완료하고자 하는 모임의 식별자(ID)
+     * @param hostId 완료 처리를 요청하는 호스트 사용자의 식별자(ID)
+     * @return 모임 완료 처리 결과를 포함하는 ResponseEntity 객체
+     */
+    @PostMapping("/{meetingId}/complete")
+    public ResponseEntity<ApiResponse<Void>> completeMeeting(
+            @PathVariable Long meetingId,
+            @AuthenticationPrincipal Long hostId) {
+        manageMeetingService.completeMeeting(meetingId, hostId);
+        return ResponseEntity.ok(ApiResponse.success("모임이 종료되었습니다.", null));
+    }
+
+
+
 }

--- a/backend/src/main/java/com/nathing/banthing/controller/MeetingController.java
+++ b/backend/src/main/java/com/nathing/banthing/controller/MeetingController.java
@@ -8,6 +8,8 @@ import com.nathing.banthing.dto.response.MeetingDetailResponse;
 import com.nathing.banthing.dto.response.MeetingSimpleResponse;
 import com.nathing.banthing.dto.response.MeetingUpdateResponse;
 import com.nathing.banthing.entity.Meeting;
+import com.nathing.banthing.exception.BusinessException;
+import com.nathing.banthing.exception.ErrorCode;
 import com.nathing.banthing.repository.MeetingsRepository;
 import com.nathing.banthing.service.CreateMeetingService;
 import com.nathing.banthing.service.DeleteMeetingService;
@@ -17,6 +19,9 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -45,9 +50,9 @@ public class MeetingController {
      * @return 생성된 모임 ID를 포함한 응답
      */
     @PostMapping
-    public ResponseEntity<ApiResponse<MeetingCreateResponse>> createMeeting(@Valid @RequestBody MeetingCreateRequest request) {
-        // TODO: 인증 로직 추가 후 userId를 실제 토큰에서 가져오도록 수정해야 합니다.
-        Long currentUserId = 1L; // 임시로 사용자 ID를 1로 설정
+    public ResponseEntity<ApiResponse<MeetingCreateResponse>> createMeeting(
+            @Valid @RequestBody MeetingCreateRequest request,
+            @AuthenticationPrincipal Long currentUserId) {
 
         Meeting newMeeting = createMeetingService.createMeeting(request, currentUserId);
 
@@ -99,10 +104,8 @@ public class MeetingController {
     @PutMapping("/update/{meetingId}")
     public ResponseEntity<ApiResponse<MeetingUpdateResponse>> updateMeeting(
             @PathVariable Long meetingId,
+            @AuthenticationPrincipal Long currentUserId,
             @Valid @RequestBody MeetingUpdateRequest request) {
-
-        // TODO: 인증 로직 추가 후 userId를 실제 토큰에서 가져오도록 수정해야 합니다.
-        Long currentUserId = 1L;
 
 
         Meeting updatedMeeting = updateMeetingService.updateMeeting(meetingId, request, currentUserId);
@@ -117,13 +120,15 @@ public class MeetingController {
 
     /**
      * 모임 삭제 API
+     *
      * @param meetingId 삭제할 모임의 ID
      * @return 성공 응답
      */
     @DeleteMapping("/delete/{meetingId}")
-    public ResponseEntity<ApiResponse<Void>> deleteMeeting(@PathVariable Long meetingId) {
-        // TODO: 인증 로직이 완성되면 실제 토큰에서 userId를 가져와야 합니다.
-        Long currentUserId = 1L; // 임시 사용자 ID (호스트라고 가정)
+    public ResponseEntity<ApiResponse<Void>> deleteMeeting(
+            @PathVariable Long meetingId,
+            @AuthenticationPrincipal Long currentUserId) {
+
 
         deleteMeetingService.deleteMeeting(meetingId, currentUserId);
 

--- a/backend/src/main/java/com/nathing/banthing/dto/request/MeetingCreateRequest.java
+++ b/backend/src/main/java/com/nathing/banthing/dto/request/MeetingCreateRequest.java
@@ -4,6 +4,7 @@ import jakarta.validation.constraints.Future;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -35,6 +36,7 @@ import java.time.LocalDateTime;
  */
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
 public class MeetingCreateRequest {
 
     @NotNull(message = "마트 ID는 필수입니다.")

--- a/backend/src/main/java/com/nathing/banthing/dto/request/MeetingUpdateRequest.java
+++ b/backend/src/main/java/com/nathing/banthing/dto/request/MeetingUpdateRequest.java
@@ -4,6 +4,7 @@ import jakarta.validation.constraints.Future;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -37,6 +38,7 @@ import java.time.LocalDateTime;
  */
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
 public class MeetingUpdateRequest {
 
     @NotNull(message = "마트 ID는 필수입니다.")

--- a/backend/src/main/java/com/nathing/banthing/dto/response/MeetingParticipantResponse.java
+++ b/backend/src/main/java/com/nathing/banthing/dto/response/MeetingParticipantResponse.java
@@ -1,0 +1,53 @@
+package com.nathing.banthing.dto.response;
+
+import com.nathing.banthing.entity.MeetingParticipant;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * MeetingParticipantResponse 클래스는 클라이언트에게 모임 참여자 정보를 응답으로 전달하기 위한 DTO(Data Transfer Object)입니다.
+ *
+ * 이 클래스는 특정 모임의 개별 참여자 정보를 정형화된 형태로 제공하기 위해 설계되었습니다.
+ * 주로 Controller 계층에서 API 응답으로 사용되며, 엔티티 객체인 MeetingParticipant를 기반으로 데이터를 생성합니다.
+ *
+ * 주요 역할:
+ * - 특정 모임의 참여자 정보를 추출하여 클라이언트 요청에 적합한 형태로 전달합니다.
+ * - 데이터를 캡슐화하여 응답 간의 데이터 일관성을 유지합니다.
+ *
+ * 필드 설명:
+ * - userId: 참여자의 고유 사용자 ID.
+ * - nickname: 참여자의 닉네임.
+ * - profileImageUrl: 참여자의 프로필 이미지 URL.
+ * - trusterScore: 참여자의 신뢰 점수.
+ * - noShowCount: 참여자의 No-Show 발생 횟수.
+ * - applicationStatus: 참여자의 모임 신청 상태 (예: PENDING, APPROVED 등).
+ *
+ * 생성자:
+ * - MeetingParticipantResponse(MeetingParticipant participant):
+ *   MeetingParticipant 엔티티 객체를 기반으로 필드를 초기화합니다.
+ *   내부적으로 참여자(User) 객체의 정보를 통해 필요한 데이터를 추출합니다.
+ * @author 고동현
+ * @since 2025-09-15
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MeetingParticipantResponse {
+
+    private Long userId;
+    private String nickname;
+    private String profileImageUrl;
+    private int TrusterScore;
+    private int noShowCount;
+    private String applicationStatus; // PENDING, APPROVED 등
+
+    // 생성자나 from 메서드를 통해 엔티티를 DTO로 변환
+    public MeetingParticipantResponse(MeetingParticipant participant) {
+        this.userId = participant.getUser().getUserId();
+        this.nickname = participant.getUser().getNickname();
+        this.profileImageUrl = participant.getUser().getProfileImageUrl();
+        this.TrusterScore = participant.getUser().getTrustScore();
+        this.noShowCount = participant.getUser().getNoShowCount();
+        this.applicationStatus = participant.getApplicationStatus().name();
+    }
+}

--- a/backend/src/main/java/com/nathing/banthing/entity/Meeting.java
+++ b/backend/src/main/java/com/nathing/banthing/entity/Meeting.java
@@ -1,6 +1,8 @@
 package com.nathing.banthing.entity;
 
 import com.nathing.banthing.dto.request.MeetingUpdateRequest;
+import com.nathing.banthing.exception.BusinessException;
+import com.nathing.banthing.exception.ErrorCode;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
@@ -105,4 +107,38 @@ public class Meeting {
         this.meetingDate = request.getMeetingDate();
         this.thumbnailImageUrl = request.getThumbnailImageUrl();
     }
-}
+
+    // '모집 완료'는 상태를 FULL로 변경
+    public void closeRecruitment() {
+        if (this.status != MeetingStatus.RECRUITING) {
+            throw new BusinessException(ErrorCode.INVALID_MEETING_STATUS);
+        }
+        this.status = MeetingStatus.FULL;
+    }
+
+    // '모집 재개'는 상태를 RECRUITING으로 변경
+    public void reopenRecruitment() {
+        if (this.status != MeetingStatus.FULL) {
+            throw new BusinessException(ErrorCode.INVALID_MEETING_STATUS);
+        }
+        this.status = MeetingStatus.RECRUITING;
+    }
+
+    // '모임 시작'은 FULL 상태에서 ONGOING으로 변경
+    public void startMeeting() {
+        if (this.status != MeetingStatus.FULL) {
+            throw new BusinessException(ErrorCode.INVALID_MEETING_STATUS);
+        }
+        this.status = MeetingStatus.ONGOING;
+    }
+
+    // '모임 종료'는 ONGOING 상태에서 COMPLETED로 변경 (기존 로직 유지)
+    public void completeMeeting() {
+        if (this.status != MeetingStatus.ONGOING) {
+            throw new BusinessException(ErrorCode.INVALID_MEETING_STATUS);
+        }
+        this.status = MeetingStatus.COMPLETED;
+    }
+
+    }
+

--- a/backend/src/main/java/com/nathing/banthing/entity/MeetingParticipant.java
+++ b/backend/src/main/java/com/nathing/banthing/entity/MeetingParticipant.java
@@ -46,6 +46,7 @@ public class MeetingParticipant {
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
+
     public enum ParticipantType {
         HOST, PARTICIPANT
     }
@@ -61,5 +62,14 @@ public class MeetingParticipant {
 
     public boolean isApproved() {
         return applicationStatus == ApplicationStatus.APPROVED;
+    }
+
+
+    // 참가 신청을 승인하는 비즈니스 메서드 추가
+    public void approve() {
+        // 이미 승인된 상태가 아닌, '대기중'일 때만 상태를 변경
+        if (this.applicationStatus == ApplicationStatus.PENDING) {
+            this.applicationStatus = ApplicationStatus.APPROVED;
+        }
     }
 }

--- a/backend/src/main/java/com/nathing/banthing/exception/ErrorCode.java
+++ b/backend/src/main/java/com/nathing/banthing/exception/ErrorCode.java
@@ -9,17 +9,37 @@ import lombok.Getter;
  * @since 2025-09-11
  * 애플리케이션에서 발생하는 에러 코드들을 정의 하는 열거체
  * 에러상태코드, 에러메시지, 에러 이름 함께 관리합니다.
- *
+ * <p>
  * 에러 코드 추가 시 이름 및 에러 코드 목적 작성 부탁드립니다.
  * ex) code: INTERNAL_SERVER_ERROR, 목적 : 서버 내부 오류 메시지용  - 이름
- *
- *  MEETING_NOT_FOUND("MEETING_NOT_FOUND", "모임을 찾을 수 없습니다.", 404) - 고동현
- *  AUTHENTICATION_NOT_FOUND("AUTHENTICATION_NOT_FOUND", "인증 정보를 찾을 수 없습니다.", 401) - 고동현
- *  INVALID_USER_ID_FORMAT("INVALID_USER_ID_FORMAT", "사용자 ID 형식이 올바르지 않습니다.", 400) - 고동현
+ * <p>
+ * MEETING_NOT_FOUND("MEETING_NOT_FOUND", "모임을 찾을 수 없습니다.", 404) - 고동현
+ * AUTHENTICATION_NOT_FOUND("AUTHENTICATION_NOT_FOUND", "인증 정보를 찾을 수 없습니다.", 401) - 고동현
+ * INVALID_USER_ID_FORMAT("INVALID_USER_ID_FORMAT", "사용자 ID 형식이 올바르지 않습니다.", 400) - 고동현
+ * PARTICIPANT_NOT_FOUND("PARTICIPANT_NOT_FOUND", "참가자를 찾을 수 없습니다.", 404) - 고동현
+ * MEETING_IS_NOT_RECRUITING("MEETING_IS_NOT_RECRUITING", "모집 중인 모임이 아닙니다.", 400) - 고동현
+ * ALREADY_PARTICIPATED("ALREADY_PARTICIPATED", "이미 참여했거나 신청한 모임입니다.", 409) - 고동현
+ * CANNOT_JOIN_AS_HOST("CANNOT_JOIN_AS_HOST", "모임 호스트는 참가 신청할 수 없습니다.", 400) - 고동현
+ * PARTICIPANT_APPLICATION_STATUS_INVALID("PARTICIPANT_APPLICATION_STATUS_INVALID", "참가 신청 상태가 올바르지 않습니다.", 400)- 고동현
+ * MEETING_IS_FULL("MEETING_IS_FULL", "모임 정원이 다 찼습니다.", 400) - 고동현
  */
 @Getter
 @AllArgsConstructor
 public enum ErrorCode {
+
+    // 참가자 관련 에러 코드
+    PARTICIPANT_NOT_FOUND("PARTICIPANT_NOT_FOUND", "참가자를 찾을 수 없습니다.", 404),
+    MEETING_IS_NOT_RECRUITING("MEETING_IS_NOT_RECRUITING", "모집 중인 모임이 아닙니다.", 400),
+    ALREADY_PARTICIPATED("ALREADY_PARTICIPATED", "이미 참여했거나 신청한 모임입니다.", 409),
+    CANNOT_JOIN_AS_HOST("CANNOT_JOIN_AS_HOST", "모임 호스트는 참가 신청할 수 없습니다.", 400),
+    PARTICIPANT_APPLICATION_STATUS_INVALID("PARTICIPANT_APPLICATION_STATUS_INVALID", "참가 신청 상태가 올바르지 않습니다.", 400),
+    MEETING_IS_FULL("MEETING_IS_FULL", "모임 정원이 다 찼습니다.", 400),
+
+    // 모임 관련 에러코드
+    INVALID_MEETING_STATUS("INVALID_MEETING_STATUS", "잘못된 모임 상태입니다.", 400),
+    MEETING_FULL("MEETING_FULL", "모임 정원이 초과되었습니다.", 400),
+    NOT_MEETING_HOST("NOT_MEETING_HOST", "모임 호스트가 아닙니다.", 403),
+
 
     // 기본 에러 코드
     INTERNAL_SERVER_ERROR("INTERNAL_SERVER_ERROR", "서버 내부 오류가 발생했습니다.", 500),
@@ -49,19 +69,10 @@ public enum ErrorCode {
 
     // 마트 관련 에러 코드
     MART_NOT_FOUND("MART_NOT_FOUND", "마트를 찾을 수 없습니다.", 404),
-    TRIP_TITLE_ALREADY_EXISTS("TRIP_TITLE_ALREADY_EXISTS", "이미 존재하는 여행 제목입니다.", 409),
-    TRIP_ACCESS_DENIED("TRIP_ACCESS_DENIED", "해당 여행에 접근할 권한이 없습니다.", 403),
     MEETING_NOT_FOUND("MEETING_NOT_FOUND", "모임을 찾을 수 없습니다.", 404),
 
-    // 여행일지 관련 에러 코드
-    TRAVEL_LOG_NOT_FOUND("TRAVEL_LOG_NOT_FOUND", "여행일지를 찾을 수 없습니다.", 404),
-    TRAVEL_LOG_ACCESS_DENIED("TRAVEL_LOG_ACCESS_DENIED", "해당 여행일지에 접근할 권한이 없습니다.", 403),
-    TRAVEL_LOG_TITLE_ALREADY_EXISTS("TRAVEL_LOG_TITLE_ALREADY_EXISTS", "이미 존재하는 여행일지 제목입니다.", 409),
-
     // 태그 관련 에러 코드
-    HASHTAG_EXISTS("HASHTAG_EXISTS", "이미 존재하는 해시태그입니다.", 409)
-
-    ;
+    HASHTAG_EXISTS("HASHTAG_EXISTS", "이미 존재하는 해시태그입니다.", 409);
 
     private final String code;
     private final String message;

--- a/backend/src/main/java/com/nathing/banthing/exception/ErrorCode.java
+++ b/backend/src/main/java/com/nathing/banthing/exception/ErrorCode.java
@@ -12,6 +12,10 @@ import lombok.Getter;
  *
  * 에러 코드 추가 시 이름 및 에러 코드 목적 작성 부탁드립니다.
  * ex) code: INTERNAL_SERVER_ERROR, 목적 : 서버 내부 오류 메시지용  - 이름
+ *
+ *  MEETING_NOT_FOUND("MEETING_NOT_FOUND", "모임을 찾을 수 없습니다.", 404) - 고동현
+ *  AUTHENTICATION_NOT_FOUND("AUTHENTICATION_NOT_FOUND", "인증 정보를 찾을 수 없습니다.", 401) - 고동현
+ *  INVALID_USER_ID_FORMAT("INVALID_USER_ID_FORMAT", "사용자 ID 형식이 올바르지 않습니다.", 400) - 고동현
  */
 @Getter
 @AllArgsConstructor
@@ -34,6 +38,8 @@ public enum ErrorCode {
     DUPLICATE_USERNAME("DUPLICATE_USERNAME", "이미 사용 중인 사용자명입니다.", 409),
     DUPLICATE_EMAIL("DUPLICATE_EMAIL", "이미 사용 중인 이메일입니다.", 409),
     INVALID_PASSWORD("INVALID_PASSWORD", "비밀번호가 올바르지 않습니다.", 401),
+    AUTHENTICATION_NOT_FOUND("AUTHENTICATION_NOT_FOUND", "인증 정보를 찾을 수 없습니다.", 401),
+    INVALID_USER_ID_FORMAT("INVALID_USER_ID_FORMAT", "사용자 ID 형식이 올바르지 않습니다.", 400),
 
     // 파일 관련 에러 코드
     FILE_SIZE_EXCEEDED("FILE_SIZE_EXCEEDED", "파일 크기가 제한을 초과했습니다.", 400),

--- a/backend/src/main/java/com/nathing/banthing/repository/MeetingParticipantsRepository.java
+++ b/backend/src/main/java/com/nathing/banthing/repository/MeetingParticipantsRepository.java
@@ -1,7 +1,24 @@
 package com.nathing.banthing.repository;
 
+import com.nathing.banthing.entity.Meeting;
 import com.nathing.banthing.entity.MeetingParticipant;
+import com.nathing.banthing.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface MeetingParticipantsRepository extends JpaRepository<MeetingParticipant, Long> {
+
+    // 특정 모임과 사용자로 참가자 존재 여부 확인 (중복 신청 방지)
+    boolean existsByMeetingAndUser(Meeting meeting, User user);
+
+    // 특정 모임의 특정 상태에 해당하는 참가자 목록 조회
+    List<MeetingParticipant> findByMeetingAndApplicationStatus(Meeting meeting, MeetingParticipant.ApplicationStatus applicationStatus);
+
+    // 특정 모임의 특정 사용자를 조회
+    Optional<MeetingParticipant> findByMeetingAndUser(Meeting meeting, User user);
+
+
+    long countByMeetingAndApplicationStatus(Meeting meeting, MeetingParticipant.ApplicationStatus status);
 }

--- a/backend/src/main/java/com/nathing/banthing/repository/MeetingsRepository.java
+++ b/backend/src/main/java/com/nathing/banthing/repository/MeetingsRepository.java
@@ -3,5 +3,12 @@ package com.nathing.banthing.repository;
 import com.nathing.banthing.entity.Meeting;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 public interface MeetingsRepository extends JpaRepository<Meeting, Long> {
+
+
+    // 특정 상태이면서 모임 시간이 지난 모임들 조회
+    List<Meeting> findByStatusAndMeetingDateBefore(Meeting.MeetingStatus status, LocalDateTime dateTime);
 }

--- a/backend/src/main/java/com/nathing/banthing/service/CreateMeetingService.java
+++ b/backend/src/main/java/com/nathing/banthing/service/CreateMeetingService.java
@@ -53,6 +53,11 @@ public class CreateMeetingService {
      */
     public Meeting createMeeting(MeetingCreateRequest request, Long userId) {
 
+        // userId가 null인지 검증
+        if (userId == null) {
+            throw new BusinessException(ErrorCode.AUTHENTICATION_NOT_FOUND);
+        }
+
         // 사용자 정보 조회
         User hostUser = usersRepository.findById(userId).orElseThrow(
                 ()->new BusinessException(ErrorCode.USER_NOT_FOUND));

--- a/backend/src/main/java/com/nathing/banthing/service/JoinMeetingService.java
+++ b/backend/src/main/java/com/nathing/banthing/service/JoinMeetingService.java
@@ -1,0 +1,121 @@
+package com.nathing.banthing.service;
+
+import com.nathing.banthing.dto.response.MeetingParticipantResponse;
+import com.nathing.banthing.entity.Meeting;
+import com.nathing.banthing.entity.User;
+import com.nathing.banthing.entity.MeetingParticipant;
+import com.nathing.banthing.exception.BusinessException;
+import com.nathing.banthing.exception.ErrorCode;
+import com.nathing.banthing.repository.MeetingParticipantsRepository;
+import com.nathing.banthing.repository.MeetingsRepository;
+import com.nathing.banthing.repository.UsersRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import java.util.List;
+import java.util.stream.Collectors;
+
+
+/**
+ * JoinMeetingService 클래스는 모임 참가 신청 및 관련 로직을 처리하는 서비스 클래스입니다.
+ * 이 클래스는 모임에 참가를 원하는 사용자와 모임 간의 상호작용을 관리하며,
+ * 모임 호스트를 위한 참가 신청 관리 기능도 제공합니다.
+ *
+ * 주요 기능:
+ * 1. 모임 참가 신청
+ * 2. 참가 신청 목록 조회
+ *
+ * 클래스 내부의 모든 비즈니스 로직은 트랜잭션 관리 하에 실행됩니다.
+ *
+ * @author 고동현
+ * @since - 2025-09-15
+ */
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+
+public class JoinMeetingService {
+
+    private final MeetingsRepository meetingsRepository;
+    private final UsersRepository usersRepository;
+    private final MeetingParticipantsRepository meetingParticipantsRepository;
+
+    /**
+     * 모임 참가 신청 로직
+     *
+     * @param meetingId 신청할 모임 ID
+     * @param userId 신청하는 사용자 ID
+     */
+    @Transactional
+    public void joinMeeting(Long meetingId, Long userId) {
+        // 1. 모임 존재 여부 및 모집 상태 확인
+        Meeting meeting = meetingsRepository.findById(meetingId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEETING_NOT_FOUND));
+
+        if (meeting.getStatus() != Meeting.MeetingStatus.RECRUITING) {
+            throw new BusinessException(ErrorCode.MEETING_IS_NOT_RECRUITING);
+        }
+
+        // 2. 신청하는 사용자 정보 확인
+        User user = usersRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        // 3. 중복 신청 방지
+        boolean alreadyParticipated = meetingParticipantsRepository.existsByMeetingAndUser(meeting, user);
+        if (alreadyParticipated) {
+            throw new BusinessException(ErrorCode.ALREADY_PARTICIPATED);
+        }
+
+        // 4. 모임 호스트는 참가 신청할 수 없도록 방지
+        if (meeting.getHostUser().getUserId().equals(userId)) {
+            throw new BusinessException(ErrorCode.CANNOT_JOIN_AS_HOST);
+        }
+
+        // 5. 모임 정원 체크
+        long currentParticipantCount = meetingParticipantsRepository
+                .countByMeetingAndApplicationStatus(meeting, MeetingParticipant.ApplicationStatus.APPROVED);
+        
+        if (currentParticipantCount >= meeting.getMaxParticipants()) {
+            throw new BusinessException(ErrorCode.MEETING_IS_FULL); // 새로운 에러 코드 필요
+        }
+
+        // 6. MeetingParticipant 엔티티 생성 (신청 대기 상태)
+        MeetingParticipant newParticipant = MeetingParticipant.builder()
+                .meeting(meeting)
+                .user(user)
+                .participantType(MeetingParticipant.ParticipantType.PARTICIPANT)
+                .applicationStatus(MeetingParticipant.ApplicationStatus.PENDING)
+                .build();
+
+        meetingParticipantsRepository.save(newParticipant);
+    }
+
+    /**
+     * 모임 참가 신청 목록 조회 로직 (호스트 전용)
+     *
+     * @param meetingId 신청 목록을 조회할 모임 ID
+     * @param userId 요청을 보낸 사용자 ID (호스트인지 확인)
+     * @return 참가 신청 목록 DTO
+     */
+    @Transactional(readOnly = true)
+    public List<MeetingParticipantResponse> getPendingParticipants(Long meetingId, Long userId) {
+
+        // 1. 모임 존재 및 호스트 권한 확인
+        Meeting meeting = meetingsRepository.findById(meetingId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEETING_NOT_FOUND));
+
+        if (!meeting.getHostUser().getUserId().equals(userId)) {
+            throw new BusinessException(ErrorCode.FORBIDDEN);
+        }
+
+        // 2. 대기 상태인 참가자 목록 조회
+        List<MeetingParticipant> participants = meetingParticipantsRepository
+                .findByMeetingAndApplicationStatus(meeting, MeetingParticipant.ApplicationStatus.PENDING);
+
+        // 3. DTO로 변환하여 반환
+        return participants.stream()
+                .map(MeetingParticipantResponse::new)
+                .collect(Collectors.toList());
+    }
+}

--- a/backend/src/main/java/com/nathing/banthing/service/ManageMeetingService.java
+++ b/backend/src/main/java/com/nathing/banthing/service/ManageMeetingService.java
@@ -1,0 +1,116 @@
+package com.nathing.banthing.service;
+
+import com.nathing.banthing.entity.Meeting;
+import com.nathing.banthing.entity.MeetingParticipant;
+import com.nathing.banthing.entity.User;
+import com.nathing.banthing.exception.BusinessException;
+import com.nathing.banthing.exception.ErrorCode;
+import com.nathing.banthing.repository.MeetingParticipantsRepository;
+import com.nathing.banthing.repository.MeetingsRepository;
+import com.nathing.banthing.repository.UsersRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/**
+ * ManageMeetingService 클래스는 모임 관리와 관련된 주요 비즈니스 로직을 제공하는 서비스 클래스입니다.
+ * 모임에 대한 승인, 마감, 탈퇴, 완료 등의 작업을 담당하며, 데이터베이스와의 상호작용을 위해
+ * MeetingsRepository, MeetingParticipantsRepository, UsersRepository를 의존합니다.
+ *
+ * @author 고동현
+ * @since - 2025-09-15
+ */
+
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ManageMeetingService {
+
+    private final MeetingsRepository meetingsRepository;
+    private final MeetingParticipantsRepository meetingParticipantsRepository;
+    private final UsersRepository usersRepository;
+
+
+
+
+    /**
+     * 참가 신청 수락
+     */
+    public void approveParticipant(Long meetingId, Long participantId, Long hostId) {
+        Meeting meeting = meetingsRepository.findById(meetingId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEETING_NOT_FOUND));
+
+        // 호스트 권한 확인
+        if (!meeting.getHostUser().getUserId().equals(hostId)) {
+            throw new BusinessException(ErrorCode.FORBIDDEN);
+        }
+
+        MeetingParticipant participant = meetingParticipantsRepository.findById(participantId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.PARTICIPANT_NOT_FOUND));
+
+        // 승인 처리
+        participant.approve();
+
+        // 참가자 수 업데이트 시에도 count 쿼리 사용
+        long approvedCount = meetingParticipantsRepository
+                .countByMeetingAndApplicationStatus(meeting, MeetingParticipant.ApplicationStatus.APPROVED);
+
+        meeting.setCurrentParticipants((int) approvedCount);
+
+        // 최대 인원 도달 시 자동 모집 마감
+        if (approvedCount >= meeting.getMaxParticipants()) {
+            meeting.closeRecruitment();
+        }
+    }
+
+    /**
+     * 모임 수동 모집 마감
+     */
+    public void closeRecruitment(Long meetingId, Long hostId) {
+        Meeting meeting = meetingsRepository.findById(meetingId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEETING_NOT_FOUND));
+
+        if (!meeting.getHostUser().getUserId().equals(hostId)) {
+            throw new BusinessException(ErrorCode.FORBIDDEN);
+        }
+
+        meeting.closeRecruitment();
+    }
+
+    /**
+     * 모임 탈퇴 처리
+     */
+    public void leaveMeeting(Long meetingId, Long userId) {
+        Meeting meeting = meetingsRepository.findById(meetingId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEETING_NOT_FOUND));
+
+        User user = usersRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        MeetingParticipant participant = meetingParticipantsRepository
+                .findByMeetingAndUser(meeting, user)
+                .orElseThrow(() -> new BusinessException(ErrorCode.PARTICIPANT_NOT_FOUND));
+
+        meetingParticipantsRepository.delete(participant);
+
+        if (meeting.getStatus() == Meeting.MeetingStatus.FULL) {
+            meeting.reopenRecruitment();
+        }
+    }
+
+
+    /**
+     * 모임 종료 처리
+     */
+    public void completeMeeting(Long meetingId, Long hostId) {
+        Meeting meeting = meetingsRepository.findById(meetingId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEETING_NOT_FOUND));
+
+        if (!meeting.getHostUser().getUserId().equals(hostId)) {
+            throw new BusinessException(ErrorCode.FORBIDDEN);
+        }
+
+        meeting.completeMeeting();
+    }
+}

--- a/backend/src/main/java/com/nathing/banthing/service/MeetingSchedulerService.java
+++ b/backend/src/main/java/com/nathing/banthing/service/MeetingSchedulerService.java
@@ -1,0 +1,83 @@
+package com.nathing.banthing.service;
+
+import com.nathing.banthing.entity.Meeting;
+import com.nathing.banthing.repository.MeetingsRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+
+/**
+ * 이 클래스는 모임 관련 스케줄러 기능을 제공하며, 정해진 시간에 자동으로
+ * 모임의 상태를 업데이트하는 로직을 포함하고 있습니다.
+ *
+ * 주요 기능:
+ * 1. 모집 완료(FULL) 상태인 모임을 일정 시간 이후 진행 중(ONGOING) 상태로 변경.
+ * 2. 진행 중(ONGOING) 상태인 모임을 24시간 이후 완료(COMPLETED) 상태로 자동 변경.
+ *
+ * 사용되는 Spring Framework 어노테이션:
+ * - @Slf4j: 로깅 기능을 사용하기 위해 Lombok에서 제공하는 어노테이션.
+ * - @Service: 스프링 컨텍스트에 서비스 계층의 컴포넌트로 등록.
+ * - @RequiredArgsConstructor: Lombok에서 제공하며, final 필드에 대해 생성자를 자동으로 생성.
+ * - @Scheduled: 스케줄 작업을 정의하는 Spring Framework 어노테이션.
+ * - @Transactional: 데이터 저장소 작업에서 트랜잭션 처리를 보장.
+ *
+ * @author 고동현
+ * @since - 2025-09-15
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MeetingSchedulerService {
+
+    private final MeetingsRepository meetingsRepository;
+
+    /**
+     * 매 분마다 실행되어, 모집 마감(FULL) 상태이고 시작 시간이 지난 모임을
+     * 진행 중(ONGOING) 상태로 변경합니다.
+     */
+    @Scheduled(cron = "0 * * * * *")
+    @Transactional
+    public void startScheduledMeetings() {
+        log.info("Scheduler: Checking for meetings to start...");
+        LocalDateTime now = LocalDateTime.now();
+        List<Meeting> meetingsToStart = meetingsRepository
+                .findByStatusAndMeetingDateBefore(Meeting.MeetingStatus.FULL, now);
+
+        for (Meeting meeting : meetingsToStart) {
+            try {
+                meeting.startMeeting();
+                log.info("Meeting {} status updated to ONGOING", meeting.getMeetingId());
+            } catch (Exception e) {
+                log.error("Failed to start meeting {}: {}", meeting.getMeetingId(), e.getMessage());
+            }
+        }
+    }
+
+    /**
+     * 매일 자정에 실행되어, 진행 중(ONGOING)인 모임들 중
+     * 모임 시작 시간으로부터 24시간이 지난 모임들을 자동으로 완료(COMPLETED) 처리합니다.
+     */
+    @Scheduled(cron = "0 0 0 * * *")
+    @Transactional
+    public void autoCompleteMeetings() {
+        log.info("Scheduler: Checking for meetings to auto-complete...");
+        LocalDateTime oneDayAgo = LocalDateTime.now().minusDays(1);
+        List<Meeting> meetingsToComplete = meetingsRepository
+                .findByStatusAndMeetingDateBefore(Meeting.MeetingStatus.ONGOING, oneDayAgo);
+
+        for (Meeting meeting : meetingsToComplete) {
+            try {
+                meeting.completeMeeting();
+                log.info("Meeting {} auto-completed.", meeting.getMeetingId());
+            } catch (Exception e) {
+                log.error("Failed to auto-complete meeting {}: {}", meeting.getMeetingId(), e.getMessage());
+            }
+        }
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -11,6 +11,12 @@ spring:
       separator: ";"
       encoding: UTF-8
 
+  task:
+    scheduling:
+      pool:
+        size: 5
+      thread-name-prefix: meeting-scheduler-
+
 
 
   datasource:
@@ -77,3 +83,5 @@ cookie:
 app:
   oauth2-success-redirect-url: http://localhost:5173
   oauth2-failure-redirect-url: http://localhost:5173/login?from=oauth2
+
+


### PR DESCRIPTION

## PR 유형 (Type of PR)
> 해당하는 항목에 `x` 표기해주세요.
- [x] **신규 기능 (New Feature)**
- [ ] **버그 수정 (Bug Fix)**
- [x] **리팩토링 (Refactoring)**
- [ ] 문서 수정 (Update Docs)
- [ ] 기타 (Chore)

---

## PR 요약 (PR Summary)
> 이 PR이 어떤 변경을 했는지 간단히 설명해주세요.

모임(Meeting)의 **생성, 조회, 수정, 삭제(CRUD)** 와 관련된 핵심 API를 구현하였으며, 사용자가 모임에 **참가 신청**하고 호스트가 이를 **관리**하는 전체적인 비즈니스 로직을 완성했습니다. 또한, 개발 과정에서 발견된 인증 및 동시성 문제를 해결하여 코드의 안정성을 높였습니다.

---

## 관련 이슈 (Related Issue)
> 이 PR과 연결된 이슈 번호가 있다면 작성해주세요.

- Closes #30 
- Closes #33

---

## 변경 사항 (Changes)
> 변경된 파일 목록과 주요 내용을 구체적으로 적어주세요.

#### 1. 모임 CRUD 기능 구현
- **`MeetingController`, `Create/Find/Update/DeleteMeetingService`**: 모임의 생성, 전체/상세 조회, 수정, 삭제 API를 구현했습니다.
- **`Meeting` Entity**: `@SQLDelete`와 `@Where`를 사용하여 **논리적 삭제(Soft Delete)**를 적용했습니다.

#### 2. 참가 신청 및 관리 기능 구현
- **`JoinMeetingService`**: 사용자가 모임에 참가 신청하고, 호스트가 신청자 목록을 조회하는 기능을 구현했습니다.
- **`ManageMeetingService`**: 호스트가 참가 신청을 **승인**하고, **모집 마감**, **모임 종료**를 처리하는 등 모임 관리 기능을 구현했습니다. 사용자가 직접 **모임을 탈퇴**하는 로직도 포함되었습니다.

#### 3. 동시성 제어 (Pessimistic Lock)
- **`MeetingsRepository`**: 여러 사용자가 동시에 참가 신청할 경우 발생할 수 있는 **동시성 문제**를 방지하기 위해, `findById` 메서드에 **비관적 락(Pessimistic Lock)**을 적용하여 데이터 정합성을 확보했습니다.


---

## 스크린샷 / 미리보기 (Preview)
> UI/UX 변경 사항이 있다면 스크린샷을 첨부해주세요.

(백엔드 기능 구현으로 해당 사항 없음)

---

## 셀프 체크리스트 (Self-Checklist)
- [x] 제목 규칙을 지켰습니다.
- [ ] 관련 이슈를 연결했습니다.
- [x] 브랜치 전략을 준수했습니다.
- [ ] 테스트 코드를 추가했거나, 기존 테스트가 모두 통과하는 것을 확인했습니다. **(Note: 단위/통합 테스트는 본 PR 병합 후 별도 PR로 진행할 예정입니다.)**

---

## 리뷰어에게 (To Reviewers)
> 리뷰 시 유의해야 할 부분, 확인이 필요한 특정 내용이 있다면 작성해주세요.

- 테스트는 현재 인증이 불가하여 테스트는 추후에 진행 후 버그가 생기면 수정해보겠습니다.

- 참가 신청 로직(`JoinMeetingService`)에 적용된 비관적 락이 동시성 제어에 적절한 선택이었는지 함께 검토해주시면 좋겠습니다.