### PR TITLE
[Feat]: [BE] 호스트 전용 참가자 목록 조회 API 개선 (#49)

### DIFF
--- a/backend/src/main/java/com/nathing/banthing/controller/MeetingController.java
+++ b/backend/src/main/java/com/nathing/banthing/controller/MeetingController.java
@@ -162,6 +162,11 @@ public class MeetingController {
         return ResponseEntity.ok(apiResponse);
     }
 
+
+    // ================================ 여기서 부터는 모임 신청 관련 api ================================== /
+
+
+
     /**
      * 모임 참가 신청 API
      *
@@ -181,21 +186,23 @@ public class MeetingController {
         return ResponseEntity.ok(apiResponse);
     }
 
+
     /**
-     * 모임 참가 신청 목록 조회 API (호스트 전용)
+     * 모임 참가자 목록 조회 API (호스트 전용)
+     * 호스트에게는 확정된 멤버와 신청 대기자 목록을 모두 반환합니다.
      *
      * @param meetingId 신청 목록을 조회할 모임의 ID
      * @param currentUserId 현재 로그인한 사용자의 ID (자동 주입)
-     * @return 참가 신청 목록
+     * @return 참가자 목록 (확정/대기 포함)
      */
     @GetMapping("/{meetingId}/participants")
-    public ResponseEntity<ApiResponse<List<MeetingParticipantResponse>>> getParticipants(
+    public ResponseEntity<ApiResponse<ParticipantListResponse>> getParticipants(
             @PathVariable Long meetingId,
             @AuthenticationPrincipal Long currentUserId) {
 
-        List<MeetingParticipantResponse> participants = joinMeetingService.getPendingParticipants(meetingId, currentUserId);
+        ParticipantListResponse participants = joinMeetingService.getParticipantsByStatusForHost(meetingId, currentUserId);
 
-        ApiResponse<List<MeetingParticipantResponse>> apiResponse = ApiResponse.success("참가 신청 목록이 성공적으로 조회되었습니다.", participants);
+        ApiResponse<ParticipantListResponse> apiResponse = ApiResponse.success("참가자 목록이 성공적으로 조회되었습니다.", participants);
 
         return ResponseEntity.ok(apiResponse);
     }

--- a/backend/src/main/java/com/nathing/banthing/dto/response/ParticipantListResponse.java
+++ b/backend/src/main/java/com/nathing/banthing/dto/response/ParticipantListResponse.java
@@ -1,0 +1,36 @@
+package com.nathing.banthing.dto.response;
+
+import lombok.Getter;
+import java.util.List;
+
+/**
+ * ParticipantListResponse 클래스는 모임의 참가자 목록을 응답 객체로 제공하기 위한 DTO(Data Transfer Object)입니다.
+ *
+ * 이 클래스는 특정 모임에 대한 확정된 참가자와 대기 중인 신청자의 정보를 별도로 관리하며,
+ * 클라이언트로 전달하기 적합한 구조로 데이터를 제공합니다.
+ *
+ * 주요 역할:
+ * - 확정된 참가자와 대기 중인 신청자 리스트를 구분하여 저장 및 제공.
+ * - API 응답 데이터의 일관성을 유지하고 가독성을 향상.
+ *
+ * 주요 필드:
+ * - approved: 확정된 참가자 목록을 담고 있는 필드.
+ * - pending: 대기 중인 신청자 목록을 담고 있는 필드.
+ *
+ * 생성자:
+ * - ParticipantListResponse(List<MeetingParticipantResponse> approved, List<MeetingParticipantResponse> pending):
+ *   각 필드를 전달받은 List를 통해 초기화하며, 각 리스트는 확정된 참가자와 대기 중인 신청자를 분리하여 저장.
+ *
+ * @author  고동현
+ * @since 2025-09-16
+ */
+@Getter
+public class ParticipantListResponse {
+    private final List<MeetingParticipantResponse> approved; // 확정된 참가자 목록
+    private final List<MeetingParticipantResponse> pending;  // 대기중인 신청자 목록
+
+    public ParticipantListResponse(List<MeetingParticipantResponse> approved, List<MeetingParticipantResponse> pending) {
+        this.approved = approved;
+        this.pending = pending;
+    }
+}


### PR DESCRIPTION
# 🚀 Pull Request
> 제목 규칙: **[타입]: 상세 내용 (#이슈 번호)**
> 예: [Feat]: [BE] 모임 생성 API 구현 (#42)

**[Feat]: [BE] 호스트 전용 참가자 목록 조회 API 개선 (#49)**

---

## PR 유형 (Type of PR)
> 해당하는 항목에 `x` 표기해주세요.
- [x] **신규 기능 (New Feature)**
- [ ] **버그 수정 (Bug Fix)**
- [x] **리팩토링 (Refactoring)**
- [ ] 문서 수정 (Update Docs)
- [ ] 기타 (Chore)

---

## PR 요약 (PR Summary)
> 이 PR이 어떤 변경을 했는지 간단히 설명해주세요.

호스트가 모임의 참가자를 관리할 때의 사용자 경험을 개선하기 위해, 기존에 분리되어 있던 **'확정된 참가자'와 '대기중인 신청자' 목록을 하나의 API 호출로 한 번에 조회**할 수 있도록 기능을 개선했습니다.

이를 통해 프론트엔드에서 불필요한 API 요청 횟수를 줄이고, 데이터 처리 로직을 단순화하여 성능과 유지보수성을 향상시켰습니다.

---

## 관련 이슈 (Related Issue)
> 이 PR과 연결된 이슈 번호가 있다면 작성해주세요.

- Closes #49

---

## 변경 사항 (Changes)
> 변경된 파일 목록과 주요 내용을 구체적으로 적어주세요.

- `backend/dto/response/ParticipantListResponse.java`:
    - 확정(`approved`) 및 대기(`pending`) 참가자 목록을 각각 담을 수 있는 `ParticipantListResponse` DTO를 새로 추가했습니다.

- `backend/service/JoinMeetingService.java`:
    - 호스트가 요청할 경우, 확정 및 대기 상태의 모든 참가자 목록을 조회하는 `getParticipantsByStatusForHost` 메서드를 신규 구현했습니다.
    - 내부적으로 호스트 권한을 먼저 검증하여 안전하게 데이터를 제공하도록 설계했습니다.

- `backend/controller/MeetingController.java`:
    - `GET /{meetingId}/participants` API가 새로운 서비스 메서드(`getParticipantsByStatusForHost`)를 호출하도록 수정했습니다.
    - API의 응답 형식을 새로운 `ParticipantListResponse` DTO에 맞게 변경하고, API 응답 메시지를 "참가자 목록..."으로 더 명확하게 수정했습니다.

---

## 스크린샷 / 미리보기 (Preview)
> UI/UX 변경 사항이 있다면 스크린샷을 첨부해주세요.

(백엔드 로직 변경으로 해당 사항 없음)

---

## 셀프 체크리스트 (Self-Checklist)
- [x] 제목 규칙을 지켰습니다.
- [x] 관련 이슈를 연결했습니다.
- [x] 브랜치 전략을 준수했습니다.
- [x] 테스트 코드를 추가했거나, 기존 테스트가 모두 통과하는 것을 확인했습니다.

---

## 리뷰어에게 (To Reviewers)
> 리뷰 시 유의해야 할 부분, 확인이 필요한 특정 내용이 있다면 작성해주세요.

- `GET /api/meetings/{meetingId}/participants` API의 **응답 JSON 구조가 변경**되었습니다. 이제 프론트엔드에서는 이 API 하나만 호출해서 `approved`와 `pending` 키로 확정/대기자 목록에 바로 접근할 수 있습니다.
- 기존에 대기자 목록만 조회하던 `getPendingParticipants` 서비스 메서드는 현재 사용되지 않는 코드가 되었으므로, 제거했습니다.