### PR TITLE
refactor: [BE] 사용자 ID 처리 방식 providerId 기반으로 리팩토링 (#52)

### DIFF
--- a/backend/src/main/java/com/nathing/banthing/service/CreateMeetingService.java
+++ b/backend/src/main/java/com/nathing/banthing/service/CreateMeetingService.java
@@ -48,18 +48,18 @@ public class CreateMeetingService {
     /**
      * 모임 생성 비즈니스 로직
      * @param request 모임 생성에 필요한 데이터 DTO
-     * @param userId 현재 로그인하여 모임을 생성하는 사용자 ID
+     * @param providerId 현재 로그인하여 모임을 생성하는 사용자 ID
      * @return 생성된 Meeting 엔티티 정보
      */
-    public Meeting createMeeting(MeetingCreateRequest request, Long userId) {
+    public Meeting createMeeting(MeetingCreateRequest request, String providerId) {
 
         // userId가 null인지 검증
-        if (userId == null) {
+        if (providerId == null) {
             throw new BusinessException(ErrorCode.AUTHENTICATION_NOT_FOUND);
         }
 
         // 사용자 정보 조회
-        User hostUser = usersRepository.findById(userId).orElseThrow(
+        User hostUser = usersRepository.findByProviderId(providerId).orElseThrow(
                 ()->new BusinessException(ErrorCode.USER_NOT_FOUND));
 
         // 마트 정보 조회

--- a/backend/src/main/java/com/nathing/banthing/service/DeleteMeetingService.java
+++ b/backend/src/main/java/com/nathing/banthing/service/DeleteMeetingService.java
@@ -20,16 +20,16 @@ public class DeleteMeetingService {
     /**
      * 모임 논리적 삭제
      * @param meetingId 삭제할 모임의 ID
-     * @param userId 요청을 보낸 사용자의 ID (권한 확인용)
+     * @param providerId 요청을 보낸 사용자의 ID (권한 확인용)
      */
-    public void deleteMeeting(Long meetingId, Long userId) {
+    public void deleteMeeting(Long meetingId, String providerId) {
         // 1. 삭제할 모임을 조회합니다.
         //    (@Where 어노테이션 덕분에 이미 삭제된 모임은 여기서 조회되지 않습니다.)
         Meeting meeting = meetingsRepository.findById(meetingId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.MEETING_NOT_FOUND));
 
         // 2. 요청을 보낸 사용자가 모임의 호스트인지 권한을 확인합니다.
-        if (!meeting.getHostUser().getUserId().equals(userId)) {
+        if (!meeting.getHostUser().getProviderId().equals(providerId)) {
             throw new BusinessException(ErrorCode.FORBIDDEN);
         }
 
@@ -37,6 +37,6 @@ public class DeleteMeetingService {
         //    deleted_at 컬럼을 업데이트합니다. (논리적 삭제)
         meetingsRepository.delete(meeting);
 
-        log.info("모임이 논리적으로 삭제되었습니다. meetingId: {}, userId: {}", meetingId, userId);
+        log.info("모임이 논리적으로 삭제되었습니다. meetingId: {}, userId: {}", meetingId, providerId);
     }
 }

--- a/backend/src/main/java/com/nathing/banthing/service/ManageMeetingService.java
+++ b/backend/src/main/java/com/nathing/banthing/service/ManageMeetingService.java
@@ -37,12 +37,15 @@ public class ManageMeetingService {
     /**
      * 참가 신청 수락
      */
-    public void approveParticipant(Long meetingId, Long participantId, Long hostId) {
+    public void approveParticipant(Long meetingId, Long participantId, String hostProviderId) {
         Meeting meeting = meetingsRepository.findById(meetingId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.MEETING_NOT_FOUND));
 
+        User hostUser = usersRepository.findByProviderId(hostProviderId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
         // 호스트 권한 확인
-        if (!meeting.getHostUser().getUserId().equals(hostId)) {
+        if (!meeting.getHostUser().equals(hostUser)) {
             throw new BusinessException(ErrorCode.FORBIDDEN);
         }
 
@@ -52,10 +55,9 @@ public class ManageMeetingService {
         // 승인 처리
         participant.approve();
 
-        // 참가자 수 업데이트 시에도 count 쿼리 사용
+        // 참가자 수 업데이트
         long approvedCount = meetingParticipantsRepository
                 .countByMeetingAndApplicationStatus(meeting, MeetingParticipant.ApplicationStatus.APPROVED);
-
         meeting.setCurrentParticipants((int) approvedCount);
 
         // 최대 인원 도달 시 자동 모집 마감
@@ -67,11 +69,14 @@ public class ManageMeetingService {
     /**
      * 모임 수동 모집 마감
      */
-    public void closeRecruitment(Long meetingId, Long hostId) {
+    public void closeRecruitment(Long meetingId, String hostProviderId) {
         Meeting meeting = meetingsRepository.findById(meetingId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.MEETING_NOT_FOUND));
 
-        if (!meeting.getHostUser().getUserId().equals(hostId)) {
+        User hostUser = usersRepository.findByProviderId(hostProviderId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        if (!meeting.getHostUser().equals(hostUser)) {
             throw new BusinessException(ErrorCode.FORBIDDEN);
         }
 
@@ -81,11 +86,11 @@ public class ManageMeetingService {
     /**
      * 모임 탈퇴 처리
      */
-    public void leaveMeeting(Long meetingId, Long userId) {
+    public void leaveMeeting(Long meetingId, String providerId) {
         Meeting meeting = meetingsRepository.findById(meetingId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.MEETING_NOT_FOUND));
 
-        User user = usersRepository.findById(userId)
+        User user = usersRepository.findByProviderId(providerId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
         MeetingParticipant participant = meetingParticipantsRepository
@@ -103,11 +108,14 @@ public class ManageMeetingService {
     /**
      * 모임 종료 처리
      */
-    public void completeMeeting(Long meetingId, Long hostId) {
+    public void completeMeeting(Long meetingId, String hostProviderId) {
         Meeting meeting = meetingsRepository.findById(meetingId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.MEETING_NOT_FOUND));
 
-        if (!meeting.getHostUser().getUserId().equals(hostId)) {
+        User hostUser = usersRepository.findByProviderId(hostProviderId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        if (!meeting.getHostUser().equals(hostUser)) {
             throw new BusinessException(ErrorCode.FORBIDDEN);
         }
 


### PR DESCRIPTION

# 🚀 Pull Request
> 제목 규칙: **[타입]: 상세 내용 (#이슈 번호)**
> 예: [Feat]: [BE] 모임 생성 API 구현 (#52)

**refactor: [BE] 사용자 ID 처리 방식 providerId 기반으로 리팩토링 (#52)**

---

## PR 유형 (Type of PR)
> 해당하는 항목에 `x` 표기해주세요.
- [ ] **신규 기능 (New Feature)**
- [x] **버그 수정 (Bug Fix)**
- [x] **리팩토링 (Refactoring)**
- [ ] 문서 수정 (Update Docs)
- [ ] 기타 (Chore)

---

## PR 요약 (PR Summary)
> 이 PR이 어떤 변경을 했는지 간단히 설명해주세요.

JWT 토큰의 Principal 값(`providerId`, String)과 `@AuthenticationPrincipal`로 주입받으려는 타입(`Long`)이 일치하지 않아 발생하던 심각한 인증 오류를 해결했습니다.

모든 컨트롤러와 서비스 레이어에서 사용자 식별자를 **`providerId(String)`** 기준으로 사용하도록 일관성 있게 리팩토링하여, 인증이 필요한 모든 API가 정상적으로 동작하도록 수정했습니다.

---

## 관련 이슈 (Related Issue)
> 이 PR과 연결된 이슈 번호가 있다면 작성해주세요.

- Closes #52

---

## 변경 사항 (Changes)
> 변경된 파일 목록과 주요 내용을 구체적으로 적어주세요.

- `backend/controller/MeetingController.java`:
    - 인증이 필요한 모든 API 메서드의 `@AuthenticationPrincipal` 파라미터를 `Long userId`에서 **`String providerId`**로 변경했습니다.

- `backend/service/CreateMeetingService.java`:
- `backend/service/UpdateMeetingService.java`:
- `backend/service/DeleteMeetingService.java`:
- `backend/service/JoinMeetingService.java`:
- `backend/service/ManageMeetingService.java`:
    - `MeetingController` 변경에 맞춰, 관련된 모든 서비스 메서드의 파라미터 타입을 `String providerId`로 수정했습니다.
    - 내부 사용자 조회 로직을 `usersRepository.findById()`에서 **`usersRepository.findByProviderId()`**를 사용하도록 변경하여 인증 로직을 통일했습니다.

---

## 스크린샷 / 미리보기 (Preview)
> UI/UX 변경 사항이 있다면 스크린샷을 첨부해주세요.

(백엔드 로직 리팩토링으로 해당 사항 없음)

---

## 셀프 체크리스트 (Self-Checklist)
- [x] 제목 규칙을 지켰습니다.
- [x] 관련 이슈를 연결했습니다.
- [x] 브랜치 전략을 준수했습니다.
- [x] 테스트 코드를 추가했거나, 기존 테스트가 모두 통과하는 것을 확인했습니다.

---

## 리뷰어에게 (To Reviewers)
> 리뷰 시 유의해야 할 부분, 확인이 필요한 특정 내용이 있다면 작성해주세요.

이번 리팩토링은 기존의 인증 관련 런타임 버그를 해결하는 **필수적인 수정**입니다. `MeetingController`에서 호출하는 모든 서비스의 사용자 식별자 처리 방식을 `providerId` 기준으로 통일했으니, 이 부분의 일관성을 중점적으로 확인 부탁드립니다.

이제 Postman에서 Bearer 토큰을 사용한 모든 API 테스트가 정상적으로 동작할 것입니다.