### PR TITLE
[Feat]: [FE] 호스트 모임 삭제 기능 및 자동 리다이렉트 구현 (#74)

### DIFF
--- a/frontend/src/pages/MeetingDetailPage.jsx
+++ b/frontend/src/pages/MeetingDetailPage.jsx
@@ -2,7 +2,7 @@
 import React, { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useAuthStore } from '../stores/authStore';
-import { getMeetingDetail, joinMeeting, leaveMeeting, getParticipants } from '../services/meetingDetailApi';
+import { getMeetingDetail, joinMeeting, leaveMeeting, getParticipants, deleteMeeting } from '../services/meetingDetailApi';
 import { FaMapMarkerAlt, FaCalendarAlt, FaUsers, FaClock, FaEdit, FaTrash } from 'react-icons/fa';
 import Chatbot from '../components/Chatbot/Chatbot';
 import styles from './MeetingDetailPage.module.scss';
@@ -114,6 +114,25 @@ const MeetingDetailPage = () => {
 
         setComments(prev => [...prev, comment]);
         setNewComment('');
+    };
+
+    // 삭제 핸들러 추가
+    const handleDeleteMeeting = async () => {
+        if (!confirm('정말 모임을 삭제하시겠습니까? 삭제된 모임은 복구할 수 없습니다.')) return;
+
+        try {
+            const result = await deleteMeeting(id);
+            if (result.success) {
+                alert('모임이 삭제되었습니다.');
+                // 메인 페이지로 리다이렉트
+                navigate('/', { replace: true });
+            } else {
+                alert(result.message || '모임 삭제에 실패했습니다.');
+            }
+        } catch (error) {
+            console.error('모임 삭제 실패:', error);
+            alert('모임 삭제 중 오류가 발생했습니다.');
+        }
     };
 
     const formatDate = (dateString) => {
@@ -249,7 +268,10 @@ const MeetingDetailPage = () => {
                                 <button className={styles.editButton}>
                                     <FaEdit /> 수정
                                 </button>
-                                <button className={styles.deleteButton}>
+                                <button
+                                    className={styles.deleteButton}
+                                    onClick={handleDeleteMeeting}
+                                >
                                     <FaTrash /> 삭제
                                 </button>
                             </div>


### PR DESCRIPTION
# 🚀 Pull Request
**[Feat]: [FE] 호스트 모임 삭제 기능 및 자동 리다이렉트 구현 (#74 )**

---
## PR 유형 (Type of PR)
- [x] **신규 기능 (New Feature)**
- [ ] **버그 수정 (Bug Fix)**
- [ ] **리팩토링 (Refactoring)**
- [ ] 문서 수정 (Update Docs)
- [ ] 기타 (Chore)

---
## PR 요약 (PR Summary)
호스트가 자신이 생성한 모임을 안전하게 삭제할 수 있는 기능을 구현했습니다. 삭제 시 확인 모달을 통해 실수 방지하고, 삭제 완료 후 메인 페이지로 자동 리다이렉트하여 사용자 경험을 개선했습니다. 삭제된 모임은 논리적 삭제로 처리되어 데이터 무결성을 유지합니다.

---
## 관련 이슈 (Related Issue)
- Closes #74

---
## 변경 사항 (Changes)
- `frontend/src/services/meetingDetailApi.js`: deleteMeeting API 함수 추가
- `frontend/src/pages/MeetingDetailPage.jsx`: handleDeleteMeeting 핸들러 구현 및 삭제 버튼 이벤트 바인딩
- `frontend/src/pages/MeetingListPage.jsx`: 삭제된 모임 필터링을 위한 데이터 새로고침 로직
- `frontend/src/pages/MeetingDetailPage.module.scss`: 삭제 버튼 스타일링 개선

---
## 스크린샷 / 미리보기 (Preview)
**삭제 플로우:**
1. 호스트가 모임 상세 페이지에서 삭제 버튼 클릭
2. 브라우저 confirm 모달로 삭제 의사 재확인
3. 삭제 성공 시  메인 페이지로 자동 리다이렉트

---
## 셀프 체크리스트 (Self-Checklist)
- [x] 제목 규칙을 지켰습니다.
- [x] 관련 이슈를 연결했습니다.
- [x] 브랜치 전략을 준수했습니다.
- [x] 테스트 코드를 추가했거나, 기존 테스트가 모두 통과하는 것을 확인했습니다.

---
## 리뷰어에게 (To Reviewers)
**주요 확인 포인트:**
1. **권한 검증**: 호스트만 삭제 버튼이 보이는지 확인
2. **UX 플로우**: 삭제 후 메인 페이지로 이동하고, 삭제된 모임이 목록에서 제외되는지 확인
3. **데이터 일관성**: 논리적 삭제 후 해당 모임이 더 이상 조회되지 않는지 확인

**테스트 시나리오:**
- 호스트로 로그인하여 자신의 모임 삭제 시도
- 참여자로 로그인하여 삭제 버튼이 보이지 않는지 확인
- 삭제 확인 모달에서 취소 선택 시 동작 