### PR TITLE
[Feat]: [FE/BE] 모임 참여 신청 UX 개선 및 거절된 사용자 재신청 방지 #82 

### DIFF
--- a/backend/src/main/java/com/nathing/banthing/entity/Meeting.java
+++ b/backend/src/main/java/com/nathing/banthing/entity/Meeting.java
@@ -139,6 +139,7 @@ public class Meeting {
 
     // '모임 종료'는 이미 완료되거나 취소된 모임이 아니면 완료 가능하도록 수정
     public void completeMeeting() {
+        // 기존: ONGOING 상태에서만 완료 가능 → 수정: COMPLETED/CANCELLED가 아니면 완료 가능
         if (this.status == MeetingStatus.COMPLETED ||
                 this.status == MeetingStatus.CANCELLED) {
             throw new BusinessException(ErrorCode.INVALID_MEETING_STATUS);
@@ -146,5 +147,5 @@ public class Meeting {
         this.status = MeetingStatus.COMPLETED;
     }
 
-    }
+}
 

--- a/backend/src/main/java/com/nathing/banthing/entity/Meeting.java
+++ b/backend/src/main/java/com/nathing/banthing/entity/Meeting.java
@@ -137,9 +137,10 @@ public class Meeting {
         this.status = MeetingStatus.ONGOING;
     }
 
-    // '모임 종료'는 ONGOING 상태에서 COMPLETED로 변경 (기존 로직 유지)
+    // '모임 종료'는 이미 완료되거나 취소된 모임이 아니면 완료 가능하도록 수정
     public void completeMeeting() {
-        if (this.status != MeetingStatus.ONGOING) {
+        if (this.status == MeetingStatus.COMPLETED ||
+                this.status == MeetingStatus.CANCELLED) {
             throw new BusinessException(ErrorCode.INVALID_MEETING_STATUS);
         }
         this.status = MeetingStatus.COMPLETED;

--- a/backend/src/main/java/com/nathing/banthing/exception/ErrorCode.java
+++ b/backend/src/main/java/com/nathing/banthing/exception/ErrorCode.java
@@ -34,6 +34,7 @@ public enum ErrorCode {
     CANNOT_JOIN_AS_HOST("CANNOT_JOIN_AS_HOST", "모임 호스트는 참가 신청할 수 없습니다.", 400),
     PARTICIPANT_APPLICATION_STATUS_INVALID("PARTICIPANT_APPLICATION_STATUS_INVALID", "참가 신청 상태가 올바르지 않습니다.", 400),
     MEETING_IS_FULL("MEETING_IS_FULL", "모임 정원이 다 찼습니다.", 400),
+    // 거절된 사용자 재신청 방지를 위한 에러 코드 추가
     REJECTED_PARTICIPANT("REJECTED_PARTICIPANT", "거절된 사용자는 재신청할 수 없습니다.", 403),
     REJECTED_PARTICIPANT_CANNOT_REAPPLY("REJECTED_PARTICIPANT_CANNOT_REAPPLY", "참여 승인이 거절되었습니다! 다른 모임을 신청해주세요.", 403),
 

--- a/backend/src/main/java/com/nathing/banthing/exception/ErrorCode.java
+++ b/backend/src/main/java/com/nathing/banthing/exception/ErrorCode.java
@@ -34,6 +34,8 @@ public enum ErrorCode {
     CANNOT_JOIN_AS_HOST("CANNOT_JOIN_AS_HOST", "모임 호스트는 참가 신청할 수 없습니다.", 400),
     PARTICIPANT_APPLICATION_STATUS_INVALID("PARTICIPANT_APPLICATION_STATUS_INVALID", "참가 신청 상태가 올바르지 않습니다.", 400),
     MEETING_IS_FULL("MEETING_IS_FULL", "모임 정원이 다 찼습니다.", 400),
+    REJECTED_PARTICIPANT("REJECTED_PARTICIPANT", "거절된 사용자는 재신청할 수 없습니다.", 403),
+    REJECTED_PARTICIPANT_CANNOT_REAPPLY("REJECTED_PARTICIPANT_CANNOT_REAPPLY", "참여 승인이 거절되었습니다! 다른 모임을 신청해주세요.", 403),
 
     // 모임 관련 에러코드
     INVALID_MEETING_STATUS("INVALID_MEETING_STATUS", "잘못된 모임 상태입니다.", 400),

--- a/backend/src/main/java/com/nathing/banthing/service/JoinMeetingService.java
+++ b/backend/src/main/java/com/nathing/banthing/service/JoinMeetingService.java
@@ -76,6 +76,7 @@ public class JoinMeetingService {
                 .orElse(null);
 
         if (existingParticipant != null) {
+            // 거절된 사용자가 다시 신청하는 것을 방지
             if (existingParticipant.getApplicationStatus() == MeetingParticipant.ApplicationStatus.REJECTED) {
                 throw new BusinessException(ErrorCode.REJECTED_PARTICIPANT_CANNOT_REAPPLY);
             }

--- a/frontend/src/pages/MeetingDetailPage.jsx
+++ b/frontend/src/pages/MeetingDetailPage.jsx
@@ -10,7 +10,8 @@ import {
     deleteMeeting,
     getComments,
     postComment,
-    updateComments
+    updateComments,
+    completeMeeting,
     // deleteComments
 } from '../services/meetingDetailApi';
 // import { getMeetingDetail, joinMeeting, leaveMeeting, getParticipants,  } from '../services/meetingDetailApi';
@@ -45,7 +46,7 @@ const MeetingDetailPage = () => {
     const [isEditing, setIsEditing] = useState(false); // 수정 모드 여부
     const [editingCommentId, setEditingCommentId] = useState(null); // 수정할 댓글 ID
     const [editedCommentContent, setEditedCommentContent] = useState(''); // 수정할 댓글 내용 상태
-
+    const [isCompletingMeeting, setIsCompletingMeeting] = useState(false);
 
 
 
@@ -120,15 +121,37 @@ const MeetingDetailPage = () => {
 
         setIsJoining(true);
         try {
+            // 먼저 즉시 상태 업데이트
+            setParticipants(prev => ({
+                ...prev,
+                pending: [...prev.pending, {
+                    participantId: Date.now(),
+                    nickname: user?.nickname,
+                    userId: user?.userId,
+                    profileImageUrl: user?.profileImageUrl,
+                    trustScore: user?.trustScore || 0,
+                    applicationStatus: 'PENDING'
+                }]
+            }));
+
             const result = await joinMeeting(id);
             if (result.success) {
-                await fetchMeetingDetail();
-                await fetchParticipants();
                 alert('모임 참여 신청이 완료되었습니다!');
+                // 서버에서 최신 데이터 가져오기
             } else {
+                // 실패시 상태 롤백
+                setParticipants(prev => ({
+                    ...prev,
+                    pending: prev.pending.filter(p => p.nickname !== user?.nickname)
+                }));
                 alert(result.message || '참여 신청에 실패했습니다.');
             }
         } catch (error) {
+            // 에러시 상태 롤백
+            setParticipants(prev => ({
+                ...prev,
+                pending: prev.pending.filter(p => p.nickname !== user?.nickname)
+            }));
             console.error('모임 참여 실패:', error);
             alert('참여 신청 중 오류가 발생했습니다.');
         } finally {
@@ -154,6 +177,25 @@ const MeetingDetailPage = () => {
         }
     };
 
+    const handleCompleteMeeting = async () => {
+        if (!confirm('정말 모임을 완료하시겠습니까? 완료된 모임은 되돌릴 수 없습니다.')) return;
+
+        setIsCompletingMeeting(true);
+        try {
+            const result = await completeMeeting(id);
+            if (result.success) {
+                await fetchMeetingDetail();
+                alert('모임이 완료되었습니다.');
+            } else {
+                alert(result.message || '모임 완료 처리에 실패했습니다.');
+            }
+        } catch (error) {
+            console.error('모임 완료 처리 실패:', error);
+            alert('모임 완료 처리 중 오류가 발생했습니다.');
+        } finally {
+            setIsCompletingMeeting(false);
+        }
+    };
 
     // 모달의 수정 버튼을 눌렀을 때 실행될 함수
     // 이 함수가 부모 컴포넌트의 상태를 변경하여 수정 폼을 활성화
@@ -281,11 +323,11 @@ const MeetingDetailPage = () => {
         return statusTexts[status] || status;
     };
 
-  /*  const getTrustBadgeClass = (score) => {
-        if (score >= 500) return styles.trustGood;
-        if (score <= 100) return styles.trustWarning;
-        return styles.trustBasic;
-    };*/
+    /*  const getTrustBadgeClass = (score) => {
+          if (score >= 500) return styles.trustGood;
+          if (score <= 100) return styles.trustWarning;
+          return styles.trustBasic;
+      };*/
 
     /**
      * 현재 로그인한 사용자가 모임의 호스트인지 확인하는 함수
@@ -300,6 +342,17 @@ const MeetingDetailPage = () => {
             participants.pending.some(p => p.nickname === user?.nickname);
     };
 
+    const getParticipationStatus = () => {
+        if (participants.approved.some(p => p.nickname === user?.nickname)) {
+            return 'approved';
+        }
+        if (participants.pending.some(p => p.nickname === user?.nickname)) {
+            return 'pending';
+        }
+        return 'none';
+    };
+
+    const participationStatus = getParticipationStatus();
 
 
     /**
@@ -473,7 +526,7 @@ const MeetingDetailPage = () => {
                         </div>
                         <div className={styles.metaItem}>
                             <FaUsers />
-                            <span>{meeting.currentParticipants} / {meeting.maxParticipants}명</span>
+                            <span>{participants.approved.length} / {meeting.maxParticipants}명</span>
                         </div>
                     </div>
 
@@ -539,7 +592,7 @@ const MeetingDetailPage = () => {
 
                 {/* 탭 콘텐츠 */}
                 <div className={styles.tabContent}>
-                   {/* {activeTab === 'participants' && (
+                    {/* {activeTab === 'participants' && (
                         <div className={styles.participantsTab}>
                             <h4>확정된 참여자</h4>
                             <div className={styles.participantsList}>
@@ -605,44 +658,44 @@ const MeetingDetailPage = () => {
                         </div>
                     )}*/}
 
-                        {/* 탭 콘텐츠 */}
-                            {activeTab === 'participants' && (() => {
+                    {/* 탭 콘텐츠 */}
+                    {activeTab === 'participants' && (() => {
 
-                                // 1. meeting 데이터나 hostInfo가 아직 로드되지 않았을 경우를 대비
-                                if (!meeting || !meeting.hostInfo) {
-                                    return null;
-                                }
+                        // 1. meeting 데이터나 hostInfo가 아직 로드되지 않았을 경우를 대비
+                        if (!meeting || !meeting.hostInfo) {
+                            return null;
+                        }
 
-                                // 2. 호스트 정보를 참여자 객체와 동일한 형태
-                                const hostAsParticipant = {
-                                    ...meeting.hostInfo,
-                                    // hostInfo에는 userId가 없으므로, 고유값인 nickname을 key로 사용하도록 전달합니다.
-                                    userId: meeting.hostInfo.nickname,
-                                    participantType: 'HOST',
-                                    trustScore: meeting.hostInfo.trustScore
-                                };
+                        // 2. 호스트 정보를 참여자 객체와 동일한 형태
+                        const hostAsParticipant = {
+                            ...meeting.hostInfo,
+                            // hostInfo에는 userId가 없으므로, 고유값인 nickname을 key로 사용하도록 전달합니다.
+                            userId: meeting.hostInfo.nickname,
+                            participantType: 'HOST',
+                            trustScore: meeting.hostInfo.trustScore
+                        };
 
-                                // 3. 기존 확정 목록에서 혹시라도 중복될 수 있는 호스트를 제거하고,
-                                //    새로 만든 호스트 객체를 배열의 맨 앞에 추가
-                                const approvedWithHost = [
-                                    hostAsParticipant,
-                                    ...participants.approved.filter(p => p.nickname !== meeting.hostInfo.nickname)
-                                ];
+                        // 3. 기존 확정 목록에서 혹시라도 중복될 수 있는 호스트를 제거하고,
+                        //    새로 만든 호스트 객체를 배열의 맨 앞에 추가
+                        const approvedWithHost = [
+                            hostAsParticipant,
+                            ...participants.approved.filter(p => p.nickname !== meeting.hostInfo.nickname)
+                        ];
 
-                                // 4. 새로 조합한 확정 참여자 목록을 props로 전달
-                                return (
-                                    <ParticipantsTab
-                                        participants={{
-                                            ...participants,
-                                            approved: approvedWithHost // 수정된 배열을 전달
-                                        }}
-                                        isHost={isHost()}
-                                        onApprove={handleApprove}
-                                        onReject={handleReject}
-                                        styles={styles}
-                                    />
-                                );
-                            })()}
+                        // 4. 새로 조합한 확정 참여자 목록을 props로 전달
+                        return (
+                            <ParticipantsTab
+                                participants={{
+                                    ...participants,
+                                    approved: approvedWithHost // 수정된 배열을 전달
+                                }}
+                                isHost={isHost()}
+                                onApprove={handleApprove}
+                                onReject={handleReject}
+                                styles={styles}
+                            />
+                        );
+                    })()}
 
 
 
@@ -728,9 +781,8 @@ const MeetingDetailPage = () => {
                     )}
                 </div>
 
-                {/* 액션 버튼 */}
                 <div className={styles.actionButtons}>
-                    {!isHost() && !isParticipating() && meeting.status === 'RECRUITING' && (
+                    {!isHost() && participationStatus === 'none' && meeting.status === 'RECRUITING' && (
                         <button
                             onClick={handleJoinMeeting}
                             disabled={isJoining}
@@ -740,12 +792,31 @@ const MeetingDetailPage = () => {
                         </button>
                     )}
 
-                    {!isHost() && isParticipating() && (
+                    {!isHost() && participationStatus === 'pending' && (
+                        <button
+                            disabled
+                            className={styles.pendingButton}
+                        >
+                            신청 대기중
+                        </button>
+                    )}
+
+                    {!isHost() && participationStatus === 'approved' && (
                         <button
                             onClick={handleLeaveMeeting}
                             className={styles.leaveButton}
                         >
                             모임 탈퇴하기
+                        </button>
+                    )}
+
+                    {isHost() && (meeting.status === 'RECRUITING' || meeting.status === 'FULL' || meeting.status === 'ONGOING') && (
+                        <button
+                            onClick={handleCompleteMeeting}
+                            disabled={isCompletingMeeting}
+                            className={styles.completeButton}
+                        >
+                            {isCompletingMeeting ? '완료 처리 중...' : '모임 완료'}
                         </button>
                     )}
 

--- a/frontend/src/pages/MeetingDetailPage.module.scss
+++ b/frontend/src/pages/MeetingDetailPage.module.scss
@@ -709,7 +709,7 @@ $desktop: 1024px;
   }
 }
 
-.joinButton, .leaveButton, .backButton {
+.joinButton, .leaveButton, .backButton, .completeButton, .pendingButton {
   padding: 1rem 2rem;
   border: none;
   border-radius: 8px;
@@ -750,6 +750,28 @@ $desktop: 1024px;
 
   &:hover:not(:disabled) {
     background-color: darken($accent-color, 10%);
+  }
+}
+
+.pendingButton {
+  background-color: #95A5A6;
+  color: $white;
+  cursor: not-allowed;
+  pointer-events: none;
+
+  &:hover {
+    transform: none;
+    box-shadow: none;
+    background-color: #95A5A6;
+  }
+}
+
+.completeButton {
+  background-color: $secondary-color;
+  color: $white;
+
+  &:hover:not(:disabled) {
+    background-color: darken($secondary-color, 10%);
   }
 }
 

--- a/frontend/src/services/meetingDetailApi.js
+++ b/frontend/src/services/meetingDetailApi.js
@@ -82,6 +82,15 @@ export const joinMeeting = async (meetingId) => {
             };
         }
 
+        // 403 상태 코드 처리 추가 (거절된 사용자)
+        if (error.response?.status === 403) {
+            return {
+                success: false,
+                message: error.response.data?.message || '참여 승인이 거절되었습니다! 다른 모임을 신청해주세요.',
+                data: null
+            };
+        }
+
         if (error.response?.status === 409) {
             return {
                 success: false,


### PR DESCRIPTION
# 🚀 Pull Request
> 제목: **[Feat]: [FE/BE] 모임 참여 신청 UX 개선 및 거절된 사용자 재신청 방지 #82 **
---
## PR 유형 (Type of PR)
- [x] **신규 기능 (New Feature)**
- [ ] **버그 수정 (Bug Fix)**
- [ ] **리팩토링 (Refactoring)**
- [ ] 문서 수정 (Update Docs)
- [ ] 기타 (Chore)
---
## PR 요약 (PR Summary)
모임 참여 신청 시스템의 사용자 경험을 개선하고, 거절된 사용자의 재신청을 방지하는 기능을 추가했습니다. 
Optimistic UI 패턴을 적용하여 참여 신청 즉시 버튼 상태가 변경되며, 백엔드에서는 거절된 사용자의 재신청을 차단합니다.
---
## 관련 이슈 (Related Issue)
- Closes #(이슈번호)
---
## 변경 사항 (Changes)
**백엔드:**
- `JoinMeetingService.java`: 거절된 사용자 재신청 방지 로직 추가
- `ErrorCode.java`: 거절 관련 에러 코드 추가 (REJECTED_PARTICIPANT_CANNOT_REAPPLY)
- `Meeting.java`: 모임 완료 조건 완화 (COMPLETED/CANCELLED가 아니면 완료 가능)

**프론트엔드:**
- `MeetingDetailPage.jsx`: Optimistic UI 패턴 적용, 참여자 수 실시간 업데이트
- `MeetingDetailPage.module.scss`: pendingButton 완전 비활성화 스타일 적용
- `meetingDetailApi.js`: 403 에러 처리 추가
---
## 스크린샷 / 미리보기 (Preview)
**Before:** 참여 신청 후에도 "참여 신청하기" 버튼 유지
**After:** 참여 신청 즉시 "신청 대기중" 회색 버튼으로 변경
---
## 셀프 체크리스트 (Self-Checklist)
- [x] 제목 규칙을 지켰습니다.
- [x] 관련 이슈를 연결했습니다.
- [x] 브랜치 전략을 준수했습니다.
- [x] 테스트 코드를 추가했거나, 기존 테스트가 모두 통과하는 것을 확인했습니다.
---
## 리뷰어에게 (To Reviewers)
**주요 확인 사항:**
1. **Optimistic UI 구현**: 참여 신청 시 즉시 상태 변경 및 실패 시 롤백 처리 확인
2. **거절된 사용자 재신청 방지**: 403 에러 응답 및 적절한 알림 메시지 표시 확인 