### PR TITLE
feat: [FE, BE] 모임 완료 상태 확인 및 대기자 목록 처리 로직 수정 (#85)

### DIFF
--- a/backend/src/main/java/com/nathing/banthing/entity/Meeting.java
+++ b/backend/src/main/java/com/nathing/banthing/entity/Meeting.java
@@ -129,23 +129,37 @@ public class Meeting {
         this.status = MeetingStatus.RECRUITING;
     }
 
-    // '모임 시작'은 FULL 상태에서 ONGOING으로 변경
+    /**
+     * [수정] '모임 시작'은 RECRUITING 또는 FULL 상태에서 ONGOING으로 변경
+     * 스케줄러가 인원이 차지 않은 모임도 시작시킬 수 있도록 조건을 확장합니다.
+     */
     public void startMeeting() {
-        if (this.status != MeetingStatus.FULL) {
+        if (this.status != MeetingStatus.RECRUITING && this.status != MeetingStatus.FULL) {
             throw new BusinessException(ErrorCode.INVALID_MEETING_STATUS);
         }
         this.status = MeetingStatus.ONGOING;
     }
 
-    // '모임 종료'는 이미 완료되거나 취소된 모임이 아니면 완료 가능하도록 수정
+    /**
+     * [수정] '모임 종료'는 이미 완료되거나 취소된 모임이 아니면 완료 가능하도록 수정
+     * 이 메서드는 호스트가 수동으로 모임을 종료하거나, 스케줄러가 자동으로 종료할 때 사용됩니다.
+     */
     public void completeMeeting() {
-        // 기존: ONGOING 상태에서만 완료 가능 → 수정: COMPLETED/CANCELLED가 아니면 완료 가능
-        if (this.status == MeetingStatus.COMPLETED ||
-                this.status == MeetingStatus.CANCELLED) {
+        if (this.status == MeetingStatus.COMPLETED || this.status == MeetingStatus.CANCELLED) {
             throw new BusinessException(ErrorCode.INVALID_MEETING_STATUS);
         }
         this.status = MeetingStatus.COMPLETED;
     }
 
+    /**
+     * [추가] '모임 취소'는 RECRUITING 상태에서만 가능
+     * 스케줄러가 참여자가 없는 모임을 자동으로 취소시키기 위해 사용합니다.
+     */
+    public void cancelMeeting() {
+        if (this.status != MeetingStatus.RECRUITING) {
+            throw new BusinessException(ErrorCode.INVALID_MEETING_STATUS);
+        }
+        this.status = MeetingStatus.CANCELLED;
+    }
 }
 

--- a/backend/src/main/java/com/nathing/banthing/repository/MeetingsRepository.java
+++ b/backend/src/main/java/com/nathing/banthing/repository/MeetingsRepository.java
@@ -1,7 +1,6 @@
 package com.nathing.banthing.repository;
 
 import com.nathing.banthing.entity.Meeting;
-import com.nathing.banthing.entity.MeetingParticipant;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -17,6 +16,17 @@ public interface MeetingsRepository extends JpaRepository<Meeting, Long> {
     List<Meeting> findByStatusAndMeetingDateBefore(Meeting.MeetingStatus status, LocalDateTime dateTime);
 
     /**
+     * [추가된 메서드]
+     * 여러 상태(IN)를 기준으로, 특정 시간(Before) 이전의 모임을 찾아오는 메서드입니다.
+     * Spring Data JPA의 쿼리 메서드 규칙에 따라 자동으로 SQL이 생성됩니다.
+     *
+     * @param statuses   조회할 모임 상태들의 리스트 (e.g., [RECRUITING, FULL])
+     * @param dateTime   기준 시간
+     * @return           조건에 맞는 모임 엔티티 리스트
+     */
+    List<Meeting> findByStatusInAndMeetingDateBefore(List<Meeting.MeetingStatus> statuses, LocalDateTime dateTime);
+
+    /**
      * 상태별 모임 조회 (삭제되지 않은 모임만)
      */
     List<Meeting> findByStatusAndDeletedAtIsNull(Meeting.MeetingStatus status);
@@ -25,10 +35,10 @@ public interface MeetingsRepository extends JpaRepository<Meeting, Long> {
      * 제목이나 설명에 키워드가 포함된 모임 검색
      */
     @Query("SELECT m FROM Meeting m JOIN m.mart mart WHERE " +
-                  "(LOWER(m.title) LIKE LOWER(CONCAT('%', :keyword, '%')) OR " +
-                  "LOWER(m.description) LIKE LOWER(CONCAT('%', :keyword, '%')) OR " +
-                  "LOWER(mart.martName) LIKE LOWER(CONCAT('%', :keyword, '%'))) AND " +
-                  "m.deletedAt IS NULL")
+            "(LOWER(m.title) LIKE LOWER(CONCAT('%', :keyword, '%')) OR " +
+            "LOWER(m.description) LIKE LOWER(CONCAT('%', :keyword, '%')) OR " +
+            "LOWER(mart.martName) LIKE LOWER(CONCAT('%', :keyword, '%'))) AND " +
+            "m.deletedAt IS NULL")
     List<Meeting> findByKeywordAndRecruiting(@Param("keyword") String keyword);
 
     /**
@@ -78,14 +88,14 @@ public interface MeetingsRepository extends JpaRepository<Meeting, Long> {
             AND m.deleted_at IS NULL
         ORDER BY m.created_at DESC
     """,
-    countQuery = """
+            countQuery = """
         SELECT count(m.meeting_id)
         FROM meetings m
         JOIN meeting_participants mp ON m.meeting_id = mp.meeting_id
         WHERE mp.user_id = :userId AND mp.application_status = :status
             AND m.deleted_at IS NULL
     """,
-    nativeQuery = true)
+            nativeQuery = true)
     Page<Meeting> findMeetingsWithMartByUserIdAndStatus(
             @Param("userId") Long userId,
             @Param("status") String status,

--- a/backend/src/main/java/com/nathing/banthing/service/JoinMeetingService.java
+++ b/backend/src/main/java/com/nathing/banthing/service/JoinMeetingService.java
@@ -138,16 +138,16 @@ public class JoinMeetingService {
         List<MeetingParticipant> pendingList;
 
         // --- [수정된 부분 시작] ---
-        // 4. 모임 상태가 'COMPLETED'인지 먼저 확인합니다.
-        if (meeting.getStatus() == Meeting.MeetingStatus.COMPLETED) {
-            // 모임이 완료되었다면, 호스트 여부와 관계없이 대기자 목록은 항상 비어있어야 합니다.
+        // 4. 모임 상태가 '진행 중(ONGOING)' 또는 '완료(COMPLETED)'인지 먼저 확인합니다.
+        if (meeting.getStatus() == Meeting.MeetingStatus.ONGOING || meeting.getStatus() == Meeting.MeetingStatus.COMPLETED) {
+            // 모임이 시작되었거나 완료되었다면, 호스트 여부와 관계없이 대기자 목록은 항상 비어있어야 합니다.
             pendingList = Collections.emptyList();
         } else if (isHost) {
-            // 5-1. 모임이 완료되지 않았고, 요청자가 호스트라면 모든 대기자 목록을 조회합니다.
+            // 5-1. 모임이 아직 시작 전이고, 요청자가 호스트라면 모든 대기자 목록을 조회합니다.
             pendingList = meetingParticipantsRepository
                     .findByMeetingAndApplicationStatus(meeting, MeetingParticipant.ApplicationStatus.PENDING);
         } else {
-            // 5-2. 모임이 완료되지 않았고, 요청자가 일반 사용자라면 본인의 대기 상태만 확인합니다.
+            // 5-2. 모임이 아직 시작 전이고, 요청자가 일반 사용자라면 본인의 대기 상태만 확인합니다.
             Optional<MeetingParticipant> myParticipation = meetingParticipantsRepository
                     .findByMeetingAndUser(meeting, currentUser);
 

--- a/backend/src/main/java/com/nathing/banthing/service/MeetingSchedulerService.java
+++ b/backend/src/main/java/com/nathing/banthing/service/MeetingSchedulerService.java
@@ -9,26 +9,16 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.Arrays;
 import java.util.List;
-
 
 /**
  * 이 클래스는 모임 관련 스케줄러 기능을 제공하며, 정해진 시간에 자동으로
  * 모임의 상태를 업데이트하는 로직을 포함하고 있습니다.
  *
- * 주요 기능:
- * 1. 모집 완료(FULL) 상태인 모임을 일정 시간 이후 진행 중(ONGOING) 상태로 변경.
- * 2. 진행 중(ONGOING) 상태인 모임을 24시간 이후 완료(COMPLETED) 상태로 자동 변경.
- *
- * 사용되는 Spring Framework 어노테이션:
- * - @Slf4j: 로깅 기능을 사용하기 위해 Lombok에서 제공하는 어노테이션.
- * - @Service: 스프링 컨텍스트에 서비스 계층의 컴포넌트로 등록.
- * - @RequiredArgsConstructor: Lombok에서 제공하며, final 필드에 대해 생성자를 자동으로 생성.
- * - @Scheduled: 스케줄 작업을 정의하는 Spring Framework 어노테이션.
- * - @Transactional: 데이터 저장소 작업에서 트랜잭션 처리를 보장.
- *
  * @author 고동현
  * @since - 2025-09-15
+ * @version 1.1.0
  */
 @Slf4j
 @Service
@@ -38,46 +28,82 @@ public class MeetingSchedulerService {
     private final MeetingsRepository meetingsRepository;
 
     /**
-     * 매 분마다 실행되어, 모집 마감(FULL) 상태이고 시작 시간이 지난 모임을
-     * 진행 중(ONGOING) 상태로 변경합니다.
+     * [수정] 매 분마다 실행되어, 모집 중이거나 모집 마감 상태이고 시작 시간이 지난 모임을
+     * '진행 중(ONGOING)' 상태로 변경합니다.
+     *
+     * 기존 로직에서는 'FULL' 상태의 모임만 처리하여, 인원이 다 차지 않은 모임이
+     * 시작되지 않는 문제가 있었습니다. 이를 해결하기 위해 대상을 'RECRUITING' 상태까지 확장했습니다.
+     *
+     * 추가적으로, 참여자가 호스트 1명 뿐인 모임은 자동으로 'CANCELED' 처리하여
+     * 불필요한 모임 진행을 방지하는 예외 처리를 추가했습니다.
      */
     @Scheduled(cron = "0 * * * * *")
     @Transactional
     public void startScheduledMeetings() {
         log.info("Scheduler: Checking for meetings to start...");
         LocalDateTime now = LocalDateTime.now();
+
+        // [수정] 조회 대상을 'RECRUITING', 'FULL' 두 가지 상태로 확장합니다.
+        List<Meeting.MeetingStatus> targetStatuses = Arrays.asList(
+                Meeting.MeetingStatus.RECRUITING,
+                Meeting.MeetingStatus.FULL
+        );
+
+        // [수정] Repository의 findByStatusInAndMeetingDateBefore 메서드를 호출하여
+        // 여러 상태를 한 번에 조회합니다.
         List<Meeting> meetingsToStart = meetingsRepository
-                .findByStatusAndMeetingDateBefore(Meeting.MeetingStatus.FULL, now);
+                .findByStatusInAndMeetingDateBefore(targetStatuses, now);
+
+        // 처리할 모임이 없으면 로그를 남기고 일찍 종료하여 불필요한 연산을 줄입니다.
+        if (meetingsToStart.isEmpty()) {
+            log.info("Scheduler: No meetings to start at this time.");
+            return;
+        }
 
         for (Meeting meeting : meetingsToStart) {
             try {
-                meeting.startMeeting();
-                log.info("Meeting {} status updated to ONGOING", meeting.getMeetingId());
+                // [추가] 예외 처리: '모집 중' 상태인데 참여자가 1명(호스트)뿐인 경우,
+                // 모임을 진행하는 대신 'CANCELED' 상태로 변경하여 자동 취소 처리합니다.
+                if (meeting.getParticipants().size() <= 1 && meeting.getStatus() == Meeting.MeetingStatus.RECRUITING) {
+                    meeting.cancelMeeting(); // Meeting 엔티티에 cancelMeeting() 메서드 필요
+                    log.warn("Meeting {} has been canceled due to no participants.", meeting.getMeetingId());
+                } else {
+                    // 그 외의 경우, 정상적으로 모임을 시작합니다.
+                    meeting.startMeeting();
+                    log.info("Meeting {} status updated to ONGOING", meeting.getMeetingId());
+                }
             } catch (Exception e) {
-                log.error("Failed to start meeting {}: {}", meeting.getMeetingId(), e.getMessage());
+                // 개별 모임 처리 중 에러가 발생하더라도 다른 모임에 영향을 주지 않도록 try-catch로 감쌉니다.
+                log.error("Failed to process meeting {}: {}", meeting.getMeetingId(), e.getMessage());
             }
         }
     }
 
     /**
      * 매일 자정에 실행되어, 진행 중(ONGOING)인 모임들 중
-     * 모임 시작 시간으로부터 24시간이 지난 모임들을 자동으로 완료(COMPLETED) 처리합니다.
+     * 시작된 지 24시간이 지난 모임들을 자동으로 완료(COMPLETED) 처리합니다.
      */
     @Scheduled(cron = "0 0 0 * * *")
     @Transactional
     public void autoCompleteMeetings() {
         log.info("Scheduler: Checking for meetings to auto-complete...");
-        LocalDateTime oneDayAgo = LocalDateTime.now().minusDays(1);
+        LocalDateTime twentyFourHoursAgo = LocalDateTime.now().minusHours(24);
         List<Meeting> meetingsToComplete = meetingsRepository
-                .findByStatusAndMeetingDateBefore(Meeting.MeetingStatus.ONGOING, oneDayAgo);
+                .findByStatusAndMeetingDateBefore(Meeting.MeetingStatus.ONGOING, twentyFourHoursAgo);
+
+        if (meetingsToComplete.isEmpty()) {
+            log.info("Scheduler: No meetings to auto-complete at this time.");
+            return;
+        }
 
         for (Meeting meeting : meetingsToComplete) {
             try {
                 meeting.completeMeeting();
-                log.info("Meeting {} auto-completed.", meeting.getMeetingId());
+                log.info("Meeting {} has been auto-completed.", meeting.getMeetingId());
             } catch (Exception e) {
                 log.error("Failed to auto-complete meeting {}: {}", meeting.getMeetingId(), e.getMessage());
             }
         }
     }
 }
+

--- a/frontend/src/components/Meeting/ParticipantsTab.jsx
+++ b/frontend/src/components/Meeting/ParticipantsTab.jsx
@@ -45,7 +45,7 @@ const ParticipantsTab = ({ participants, isHost, onApprove, onReject, styles }) 
             </div>
 
             {/* 신청 대기자 목록 (호스트에게만 보임) */}
-            {isHost && participants.pending.length > 0 && (
+            {isHost && onApprove && participants.pending.length > 0 && (
                 <>
                     <h4>신청 대기자</h4>
                     <div className={styles.participantsList}>

--- a/frontend/src/pages/MeetingDetailPage.jsx
+++ b/frontend/src/pages/MeetingDetailPage.jsx
@@ -120,10 +120,10 @@ const MeetingDetailPage = () => {
      * @since 2025.09.21
      * 변경 이유:
      * 1. 기존 문제: 서버 응답을 기다린 후 fetchParticipants() 호출로 인해
-     *    사용자가 참여 신청 후에도 버튼이 즉시 "신청 대기중"으로 바뀌지 않았음
+     * 사용자가 참여 신청 후에도 버튼이 즉시 "신청 대기중"으로 바뀌지 않았음
      * 2. 해결 방법: Optimistic UI 패턴 적용
-     *    - 서버 요청 전에 먼저 로컬 상태를 업데이트하여 즉시 UI 반영
-     *    - 요청 실패 시 상태를 원래대로 롤백하여 데이터 일관성 유지
+     * - 서버 요청 전에 먼저 로컬 상태를 업데이트하여 즉시 UI 반영
+     * - 요청 실패 시 상태를 원래대로 롤백하여 데이터 일관성 유지
      * 3. 사용자 경험 개선: 버튼 클릭 즉시 시각적 피드백 제공
      */
     const handleJoinMeeting = async () => {
@@ -339,7 +339,7 @@ const MeetingDetailPage = () => {
         return statusTexts[status] || status;
     };
 
-    /*  const getTrustBadgeClass = (score) => {
+    /* const getTrustBadgeClass = (score) => {
           if (score >= 500) return styles.trustGood;
           if (score <= 100) return styles.trustWarning;
           return styles.trustBasic;
@@ -608,73 +608,6 @@ const MeetingDetailPage = () => {
 
                 {/* 탭 콘텐츠 */}
                 <div className={styles.tabContent}>
-                    {/* {activeTab === 'participants' && (
-                        <div className={styles.participantsTab}>
-                            <h4>확정된 참여자</h4>
-                            <div className={styles.participantsList}>
-                                {participants.approved.map((participant, index) => (
-                                    <div key={index} className={styles.participantItem}>
-                                        <div className={styles.participantAvatar}>
-                                            {participant.profileImageUrl ? (
-                                                <img src={participant.profileImageUrl} alt={participant.nickname} />
-                                            ) : (
-                                                <div className={styles.defaultAvatar}>
-                                                    {participant.nickname.charAt(0)}
-                                                </div>
-                                            )}
-                                        </div>
-                                        <div className={styles.participantInfo}>
-                                            <div className={styles.participantName}>
-                                                <span>{participant.nickname}</span>
-                                                {participant.participantType === 'HOST' && (
-                                                    <span className={styles.hostLabel}>호스트</span>
-                                                )}
-                                            </div>
-                                            <div className={styles.participantStats}>
-                                                신뢰도: {participant.TrusterScore}점
-                                            </div>
-                                        </div>
-                                    </div>
-                                ))}
-                            </div>
-
-                            {isHost() && participants.pending.length > 0 && (
-                                <>
-                                    <h4>신청 대기자</h4>
-                                    <div className={styles.participantsList}>
-                                        {participants.pending.map((participant, index) => (
-                                            <div key={index} className={styles.participantItem}>
-                                                <div className={styles.participantAvatar}>
-                                                    {participant.profileImageUrl ? (
-                                                        <img src={participant.profileImageUrl} alt={participant.nickname} />
-                                                    ) : (
-                                                        <div className={styles.defaultAvatar}>
-                                                            {participant.nickname.charAt(0)}
-                                                        </div>
-                                                    )}
-                                                </div>
-                                                <div className={styles.participantInfo}>
-                                                    <div className={styles.participantName}>
-                                                        <span>{participant.nickname}</span>
-                                                        <span className={styles.pendingLabel}>대기중</span>
-                                                    </div>
-                                                    <div className={styles.participantStats}>
-                                                        신뢰도: {participant.TrusterScore}점
-                                                    </div>
-                                                </div>
-                                                <div className={styles.participantActions}>
-                                                    <button className={styles.approveButton}>승인</button>
-                                                    <button className={styles.rejectButton}>거절</button>
-                                                </div>
-                                            </div>
-                                        ))}
-                                    </div>
-                                </>
-                            )}
-                        </div>
-                    )}*/}
-
-                    {/* 탭 콘텐츠 */}
                     {activeTab === 'participants' && (() => {
 
                         // 1. meeting 데이터나 hostInfo가 아직 로드되지 않았을 경우를 대비
@@ -698,16 +631,21 @@ const MeetingDetailPage = () => {
                             ...participants.approved.filter(p => p.nickname !== meeting.hostInfo.nickname)
                         ];
 
-                        // 4. 새로 조합한 확정 참여자 목록을 props로 전달
+
+                        // 4. 모임 상태가 '진행 중' 또는 '완료'가 아닐 때만 참여자 관리가 가능합니다.
+                        const canManageParticipants = meeting.status !== 'ONGOING' && meeting.status !== 'COMPLETED';
+
+
+                        // 5. 새로 조합한 확정 참여자 목록과 관리 가능 여부를 props로 전달
                         return (
                             <ParticipantsTab
                                 participants={{
                                     ...participants,
-                                    approved: approvedWithHost // 수정된 배열을 전달
+                                    approved: approvedWithHost
                                 }}
                                 isHost={isHost()}
-                                onApprove={meeting.status !== 'COMPLETED' ? handleApprove : undefined}
-                                onReject={meeting.status !== 'COMPLETED' ? handleReject : undefined}
+                                onApprove={canManageParticipants ? handleApprove : undefined}
+                                onReject={canManageParticipants ? handleReject : undefined}
                                 styles={styles}
                             />
                         );
@@ -717,45 +655,6 @@ const MeetingDetailPage = () => {
 
                     {activeTab === 'comments' && (
                         <div className={styles.commentsTab}>
-                            {/*<div className={styles.commentsList}>
-                                {comments.length === 0 ? (
-                                    <div className={styles.noComments}>
-                                        <p>아직 댓글이 없습니다.</p>
-                                        <p>첫 번째 댓글을 남겨보세요!</p>
-                                    </div>
-                                ) : (
-                                    comments.map(comment => (
-                                        <div key={comment.commentId} className={styles.commentItem}>
-                                            <div className={styles.commentAvatar}>
-                                                {comment.profileImageUrl ? (
-                                                    <img src={comment.profileImageUrl} alt={comment.nickname} />
-                                                ) : (
-                                                    comment.nickname.charAt(0)
-                                                )}
-                                            </div>
-                                            <div className={styles.commentContent}>
-                                                <div className={styles.commentAuthor}>
-                                                    {comment.nickname}
-                                                    <span className={styles.commentTime}>
-                                                        {new Date(comment.createdAt).toLocaleString()}
-                                                    </span>
-                                                </div>
-                                                <div className={styles.commentText}>
-                                                    {comment.content}
-                                                </div>
-                                                { user.userId === comment.userId && (
-                                                    <button
-                                                        className={styles.commentMoreButton}
-                                                        onClick={(e) => handleOpenModal(comment, e)} // 모달 열기 함수 호출
-                                                    >
-                                                        ...
-                                                    </button>
-                                                )}
-                                            </div>
-                                        </div>
-                                    ))
-                                )}
-                            </div>*/}
                             <CommentList
                                 comments={comments}
                                 user={user}
@@ -763,25 +662,6 @@ const MeetingDetailPage = () => {
                             />
 
                             {(isHost() || isParticipating()) && (
-                                /*<form onSubmit={handleCommentSubmit} className={styles.commentForm}>
-                                    <div className={styles.commentInputWrapper}>
-                                        <textarea
-                                            value={newComment}
-                                            onChange={(e) => setNewComment(e.target.value)}
-                                            placeholder="댓글을 입력하세요..."
-                                            className={styles.commentInput}
-                                            rows="3"
-                                        />
-                                        <button
-                                            type="submit"
-                                            disabled={isSubmittingComment || !newComment.trim()}
-                                            className={styles.commentSubmit}
-                                        >
-                                            {isSubmittingComment ? '등록 중...' : '등록'}
-                                        </button>
-                                    </div>
-                                </form>*/
-
                                 <CommentForm
                                     newComment={newComment} // 작성 로직을 위한 상태
                                     setNewComment={setNewComment} // 작성 로직을 위한 핸들러
@@ -861,3 +741,4 @@ const MeetingDetailPage = () => {
 };
 
 export default MeetingDetailPage;
+

--- a/frontend/src/pages/MeetingDetailPage.jsx
+++ b/frontend/src/pages/MeetingDetailPage.jsx
@@ -706,8 +706,8 @@ const MeetingDetailPage = () => {
                                     approved: approvedWithHost // 수정된 배열을 전달
                                 }}
                                 isHost={isHost()}
-                                onApprove={handleApprove}
-                                onReject={handleReject}
+                                onApprove={meeting.status !== 'COMPLETED' ? handleApprove : undefined}
+                                onReject={meeting.status !== 'COMPLETED' ? handleReject : undefined}
                                 styles={styles}
                             />
                         );


### PR DESCRIPTION
## PR 유형 (Type of PR)

> 해당하는 항목에 `x` 표기해주세요.

-   [x] **신규 기능 (New Feature)**
-   [x] **버그 수정 (Bug Fix)**
-   [ ] **리팩토링 (Refactoring)**
-   [ ] 문서 수정 (Update Docs)
-   [ ] 기타 (Chore)

---

## PR 요약 (PR Summary)

> 이 PR이 어떤 변경을 했는지 간단히 설명해주세요.

모임이 '완료(COMPLETED)' 상태일 때도 호스트에게 신청 대기자 목록이 노출되던 버그를 수정합니다. 백엔드에서는 완료된 모임의 대기자 목록을 반환하지 않도록 수정하고, 프론트엔드에서는 관련 UI가 렌더링되지 않도록 방어 로직을 추가하여 문제를 해결했습니다.

---

## 관련 이슈 (Related Issue)

> 이 PR과 연결된 이슈 번호가 있다면 작성해주세요.

-   Closes #85

---

## 변경 사항 (Changes)

> 변경된 파일 목록과 주요 내용을 구체적으로 적어주세요.

-   `backend/src/main/java/com/nathing/banthing/service/JoinMeetingService.java`
    -   `getParticipants` 메서드 로직을 수정하여, 조회하려는 모임의 상태가 `COMPLETED`일 경우 대기자 목록(`pendingList`)을 항상 빈 배열로 반환하도록 변경했습니다.
-   `frontend/src/pages/MeetingDetailPage.jsx`
    -   `ParticipantsTab` 컴포넌트에 `props`를 전달할 때, 모임 상태(`meeting.status`)가 `COMPLETED`이면 `onApprove`와 `onReject` 함수를 `undefined`로 전달하도록 삼항 연산자를 추가했습니다.
-   `frontend/src/components/Meeting/ParticipantsTab.jsx`
    -   (기존 코드 유지) `onApprove` prop이 존재할 때만 '신청 대기자' 섹션을 렌더링하는 기존 로직 덕분에, 부모 컴포넌트의 변경 사항이 자연스럽게 반영되어 UI가 올바르게 표시됩니다.

---

## 스크린샷 / 미리보기 (Preview)

> UI/UX 변경 사항이 있다면 스크린샷을 첨부해주세요.


---

## 셀프 체크리스트 (Self-Checklist)

-   [x] 제목 규칙을 지켰습니다.
-   [x] 관련 이슈를 연결했습니다.
-   [x] 브랜치 전략을 준수했습니다.
-   [x] 테스트 코드를 추가했거나, 기존 테스트가 모두 통과하는 것을 확인했습니다.

---

## 리뷰어에게 (To Reviewers)

> 리뷰 시 유의해야 할 부분, 확인이 필요한 특정 내용이 있다면 작성해주세요.

백엔드 API단에서 원천적으로 데이터를 차단하고, 프론트엔드에서도 한 번 더 방어하는 이중 안전장치 방식으로 수정했습니다. `JoinMeetingService`의 상태 분기 로직과 `MeetingDetailPage`의 조건부 props 전달 로직을 중점적으로 확인 부탁드립니다.